### PR TITLE
feat: add admin cache read endpoint for debugging

### DIFF
--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -206,7 +206,7 @@ func main() {
 
 		// Admin routes
 		adminGroup := v1.Group("/admin")
-		adminGroup.Use(middleware.AuthMiddleware())
+		adminGroup.Use(middleware.AuthMiddleware(), middleware.RequireAdmin())
 		{
 			adminGroup.GET("/phone/quarantined", phoneHandlers.GetQuarantinedPhones)
 			adminGroup.GET("/phone/quarantine/stats", phoneHandlers.GetQuarantineStats)
@@ -225,6 +225,9 @@ func main() {
 			adminGroup.POST("/beta/whitelist/bulk-add", betaGroupHandlers.BulkAddToWhitelist)
 			adminGroup.POST("/beta/whitelist/bulk-remove", betaGroupHandlers.BulkRemoveFromWhitelist)
 			adminGroup.POST("/beta/whitelist/bulk-move", betaGroupHandlers.BulkMoveWhitelist)
+
+			// Cache management
+			adminGroup.POST("/cache/read", handlers.ReadCacheKey)
 		}
 
 		// Config routes (public)

--- a/docs/docs.go
+++ b/docs/docs.go
@@ -653,6 +653,69 @@ const docTemplate = `{
                 }
             }
         },
+        "/admin/cache/read": {
+            "post": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Permite aos administradores ler qualquer chave do cache Redis para debug e monitoramento",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "admin"
+                ],
+                "summary": "Ler chave arbitrária do cache Redis",
+                "parameters": [
+                    {
+                        "description": "Chave do cache para ler",
+                        "name": "data",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/handlers.CacheReadRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Dados da chave do cache",
+                        "schema": {
+                            "$ref": "#/definitions/handlers.CacheReadResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Parâmetros inválidos",
+                        "schema": {
+                            "$ref": "#/definitions/handlers.ErrorResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "Token de autenticação não fornecido ou inválido",
+                        "schema": {
+                            "$ref": "#/definitions/handlers.ErrorResponse"
+                        }
+                    },
+                    "403": {
+                        "description": "Acesso negado - somente administradores",
+                        "schema": {
+                            "$ref": "#/definitions/handlers.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Erro interno do servidor",
+                        "schema": {
+                            "$ref": "#/definitions/handlers.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
         "/admin/phone/quarantine/stats": {
             "get": {
                 "description": "Obtém estatísticas sobre telefones em quarentena (apenas administradores)",
@@ -2676,6 +2739,33 @@ const docTemplate = `{
         }
     },
     "definitions": {
+        "handlers.CacheReadRequest": {
+            "type": "object",
+            "required": [
+                "key"
+            ],
+            "properties": {
+                "key": {
+                    "type": "string",
+                    "example": "citizen:12345678901"
+                }
+            }
+        },
+        "handlers.CacheReadResponse": {
+            "type": "object",
+            "properties": {
+                "exists": {
+                    "type": "boolean"
+                },
+                "key": {
+                    "type": "string"
+                },
+                "ttl_seconds": {
+                    "type": "integer"
+                },
+                "value": {}
+            }
+        },
         "handlers.EmailValidationRequest": {
             "description": "Estrutura de entrada contendo o endereço de email a ser validado.",
             "type": "object",

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -651,6 +651,69 @@
                 }
             }
         },
+        "/admin/cache/read": {
+            "post": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Permite aos administradores ler qualquer chave do cache Redis para debug e monitoramento",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "admin"
+                ],
+                "summary": "Ler chave arbitrária do cache Redis",
+                "parameters": [
+                    {
+                        "description": "Chave do cache para ler",
+                        "name": "data",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/handlers.CacheReadRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Dados da chave do cache",
+                        "schema": {
+                            "$ref": "#/definitions/handlers.CacheReadResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Parâmetros inválidos",
+                        "schema": {
+                            "$ref": "#/definitions/handlers.ErrorResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "Token de autenticação não fornecido ou inválido",
+                        "schema": {
+                            "$ref": "#/definitions/handlers.ErrorResponse"
+                        }
+                    },
+                    "403": {
+                        "description": "Acesso negado - somente administradores",
+                        "schema": {
+                            "$ref": "#/definitions/handlers.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Erro interno do servidor",
+                        "schema": {
+                            "$ref": "#/definitions/handlers.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
         "/admin/phone/quarantine/stats": {
             "get": {
                 "description": "Obtém estatísticas sobre telefones em quarentena (apenas administradores)",
@@ -2674,6 +2737,33 @@
         }
     },
     "definitions": {
+        "handlers.CacheReadRequest": {
+            "type": "object",
+            "required": [
+                "key"
+            ],
+            "properties": {
+                "key": {
+                    "type": "string",
+                    "example": "citizen:12345678901"
+                }
+            }
+        },
+        "handlers.CacheReadResponse": {
+            "type": "object",
+            "properties": {
+                "exists": {
+                    "type": "boolean"
+                },
+                "key": {
+                    "type": "string"
+                },
+                "ttl_seconds": {
+                    "type": "integer"
+                },
+                "value": {}
+            }
+        },
         "handlers.EmailValidationRequest": {
             "description": "Estrutura de entrada contendo o endereço de email a ser validado.",
             "type": "object",

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -1,5 +1,23 @@
 basePath: /v1
 definitions:
+  handlers.CacheReadRequest:
+    properties:
+      key:
+        example: citizen:12345678901
+        type: string
+    required:
+    - key
+    type: object
+  handlers.CacheReadResponse:
+    properties:
+      exists:
+        type: boolean
+      key:
+        type: string
+      ttl_seconds:
+        type: integer
+      value: {}
+    type: object
   handlers.EmailValidationRequest:
     description: Estrutura de entrada contendo o endereço de email a ser validado.
     properties:
@@ -1402,6 +1420,47 @@ paths:
       summary: Remover múltiplos telefones da whitelist
       tags:
       - Beta Whitelist
+  /admin/cache/read:
+    post:
+      consumes:
+      - application/json
+      description: Permite aos administradores ler qualquer chave do cache Redis para
+        debug e monitoramento
+      parameters:
+      - description: Chave do cache para ler
+        in: body
+        name: data
+        required: true
+        schema:
+          $ref: '#/definitions/handlers.CacheReadRequest'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: Dados da chave do cache
+          schema:
+            $ref: '#/definitions/handlers.CacheReadResponse'
+        "400":
+          description: Parâmetros inválidos
+          schema:
+            $ref: '#/definitions/handlers.ErrorResponse'
+        "401":
+          description: Token de autenticação não fornecido ou inválido
+          schema:
+            $ref: '#/definitions/handlers.ErrorResponse'
+        "403":
+          description: Acesso negado - somente administradores
+          schema:
+            $ref: '#/definitions/handlers.ErrorResponse'
+        "500":
+          description: Erro interno do servidor
+          schema:
+            $ref: '#/definitions/handlers.ErrorResponse'
+      security:
+      - BearerAuth: []
+      summary: Ler chave arbitrária do cache Redis
+      tags:
+      - admin
   /admin/phone/quarantine/stats:
     get:
       description: Obtém estatísticas sobre telefones em quarentena (apenas administradores)

--- a/internal/handlers/admin_handlers.go
+++ b/internal/handlers/admin_handlers.go
@@ -1,0 +1,133 @@
+package handlers
+
+import (
+	"net/http"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/prefeitura-rio/app-rmi/internal/config"
+	"github.com/prefeitura-rio/app-rmi/internal/observability"
+	"github.com/prefeitura-rio/app-rmi/internal/utils"
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	"go.uber.org/zap"
+)
+
+// CacheReadRequest represents a request to read from cache
+type CacheReadRequest struct {
+	Key string `json:"key" binding:"required" example:"citizen:12345678901"`
+}
+
+// CacheReadResponse represents a response from cache read
+type CacheReadResponse struct {
+	Key    string      `json:"key"`
+	Value  interface{} `json:"value"`
+	Exists bool        `json:"exists"`
+	TTL    int64       `json:"ttl_seconds"`
+}
+
+// ReadCacheKey godoc
+// @Summary Ler chave arbitrária do cache Redis
+// @Description Permite aos administradores ler qualquer chave do cache Redis para debug e monitoramento
+// @Tags admin
+// @Accept json
+// @Produce json
+// @Param data body CacheReadRequest true "Chave do cache para ler"
+// @Security BearerAuth
+// @Success 200 {object} CacheReadResponse "Dados da chave do cache"
+// @Failure 400 {object} ErrorResponse "Parâmetros inválidos"
+// @Failure 401 {object} ErrorResponse "Token de autenticação não fornecido ou inválido"
+// @Failure 403 {object} ErrorResponse "Acesso negado - somente administradores"
+// @Failure 500 {object} ErrorResponse "Erro interno do servidor"
+// @Router /admin/cache/read [post]
+func ReadCacheKey(c *gin.Context) {
+	startTime := time.Now()
+	ctx, span := otel.Tracer("").Start(c.Request.Context(), "ReadCacheKey")
+	defer span.End()
+
+	logger := observability.Logger()
+
+	// Add operation to span attributes
+	span.SetAttributes(
+		attribute.String("operation", "read_cache_key"),
+		attribute.String("service", "admin"),
+	)
+
+	logger.Debug("ReadCacheKey called")
+
+	// Parse input with tracing
+	ctx, parseSpan := utils.TraceInputParsing(ctx, "cache_read_request")
+	var request CacheReadRequest
+	if err := c.ShouldBindJSON(&request); err != nil {
+		utils.RecordErrorInSpan(parseSpan, err, map[string]interface{}{
+			"error.type": "input_parsing",
+			"input.type": "CacheReadRequest",
+		})
+		parseSpan.End()
+		logger.Error("failed to parse cache read request", zap.Error(err))
+		c.JSON(http.StatusBadRequest, ErrorResponse{Error: "Invalid request body: " + err.Error()})
+		return
+	}
+	utils.AddSpanAttribute(parseSpan, "cache.key", request.Key)
+	parseSpan.End()
+
+	// Read from Redis with tracing
+	ctx, cacheSpan := utils.TraceCacheGet(ctx, request.Key)
+	value, err := config.Redis.Get(ctx, request.Key).Result()
+
+	response := CacheReadResponse{
+		Key:    request.Key,
+		Exists: err == nil,
+		TTL:    -1,
+	}
+
+	if err == nil {
+		// Key exists, get TTL and value
+		response.Value = value
+		utils.AddSpanAttribute(cacheSpan, "cache.hit", true)
+
+		// Get TTL
+		ttl, ttlErr := config.Redis.TTL(ctx, request.Key).Result()
+		if ttlErr == nil {
+			response.TTL = int64(ttl.Seconds())
+		}
+
+		observability.CacheHits.WithLabelValues("admin_cache_read").Inc()
+		logger.Debug("cache key found",
+			zap.String("key", request.Key),
+			zap.Int("value_length", len(value)),
+			zap.Int64("ttl_seconds", response.TTL))
+	} else {
+		// Key doesn't exist or error occurred
+		response.Value = nil
+		utils.AddSpanAttribute(cacheSpan, "cache.hit", false)
+
+		if err.Error() == "redis: nil" {
+			// Key doesn't exist - this is normal
+			logger.Debug("cache key not found", zap.String("key", request.Key))
+		} else {
+			// Actual Redis error
+			utils.RecordErrorInSpan(cacheSpan, err, map[string]interface{}{
+				"cache.key": request.Key,
+			})
+			logger.Error("failed to read from cache", zap.Error(err), zap.String("key", request.Key))
+			cacheSpan.End()
+			c.JSON(http.StatusInternalServerError, ErrorResponse{Error: "Failed to read from cache: " + err.Error()})
+			return
+		}
+	}
+	cacheSpan.End()
+
+	// Serialize response with tracing
+	_, responseSpan := utils.TraceResponseSerialization(ctx, "success")
+	c.JSON(http.StatusOK, response)
+	responseSpan.End()
+
+	// Log total operation time
+	totalDuration := time.Since(startTime)
+	logger.Debug("ReadCacheKey completed",
+		zap.String("key", request.Key),
+		zap.Bool("exists", response.Exists),
+		zap.Duration("total_duration", totalDuration),
+		zap.String("status", "success"))
+}


### PR DESCRIPTION
- Add POST /v1/admin/cache/read endpoint for reading arbitrary Redis cache keys
- Requires admin authentication via middleware.RequireAdmin()
- Returns key existence, value, and TTL information
- Includes comprehensive tracing and error handling
- Useful for debugging cache issues and inspecting cached data

Usage:
POST /v1/admin/cache/read
Body: {"key": "citizen:12345678901"}

Response: {
  "key": "citizen:12345678901", "value": "...", "exists": true, "ttl_seconds": 3600 }

🤖 Generated with [Claude Code](https://claude.ai/code)