### PR TITLE
feat: service account middleware and route updates

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -176,8 +176,8 @@ When asked to do the "commit thing":
 This project follows a structured git workflow:
 
 #### Branch Structure
-- **main**: Production-ready code only
-- **staging**: Integration testing and pre-production  
+- **main**: Staging/homologation/pre-production environment — all feature branches target here
+- **releases**: Production deployments via tagged releases
 - **feature branches**: Active development work with meaningful names
 
 #### Branch Naming Convention
@@ -188,7 +188,7 @@ This project follows a structured git workflow:
 - **test/**: Test improvements (e.g., `test/integration-coverage`)
 
 #### Development Rules
-1. Always create a new feature branch from **staging** for new work
+1. Always create a new feature branch from **main** for new work
 2. Use descriptive branch names with appropriate prefixes
 3. Test every batch of implemented tasks before committing
 4. Never push commits directly - create PRs for code review

--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -158,9 +158,9 @@ func main() {
 		// Metrics endpoint (no auth required) - for Prometheus scraping
 		v1.GET("/metrics", handlers.MetricsHandler)
 
-		// Memory endpoints (require auth)
+		// Memory endpoints (require service account)
 		memory := v1.Group("/memory")
-		memory.Use(middleware.AuthMiddleware())
+		memory.Use(middleware.AuthMiddleware(), middleware.RequireServiceAccount("app-eai-agent"))
 		{
 			memory.GET("/:phone_number", handlers.GetMemoryList)
 			memory.GET("/:phone_number/:memory_name", handlers.GetMemoryByName)
@@ -173,33 +173,34 @@ func main() {
 		citizen := v1.Group("/citizen")
 		citizen.Use(middleware.AuthMiddleware())
 		{
-			// Endpoints that require own CPF access
-			citizen.GET("/:cpf", middleware.RequireOwnCPF(), handlers.GetCitizenData)
-			citizen.GET("/:cpf/wallet", middleware.RequireOwnCPF(), handlers.GetCitizenWallet)
-			citizen.GET("/:cpf/maintenance-request", middleware.RequireOwnCPF(), handlers.GetMaintenanceRequests)
-			citizen.PUT("/:cpf/address", middleware.RequireOwnCPF(), handlers.UpdateSelfDeclaredAddress)
-			citizen.PUT("/:cpf/phone", middleware.RequireOwnCPF(), handlers.UpdateSelfDeclaredPhone)
-			citizen.PUT("/:cpf/email", middleware.RequireOwnCPF(), handlers.UpdateSelfDeclaredEmail)
-			citizen.PUT("/:cpf/ethnicity", middleware.RequireOwnCPF(), handlers.UpdateSelfDeclaredRaca)
-			citizen.PUT("/:cpf/exhibition-name", middleware.RequireOwnCPF(), handlers.UpdateSelfDeclaredNomeExibicao)
-			citizen.PUT("/:cpf/gender", middleware.RequireOwnCPF(), handlers.UpdateSelfDeclaredGenero)
-			citizen.PUT("/:cpf/family-income", middleware.RequireOwnCPF(), handlers.UpdateSelfDeclaredRendaFamiliar)
-			citizen.PUT("/:cpf/education", middleware.RequireOwnCPF(), handlers.UpdateSelfDeclaredEscolaridade)
-			citizen.PUT("/:cpf/disability", middleware.RequireOwnCPF(), handlers.UpdateSelfDeclaredDeficiencia)
-			citizen.GET("/:cpf/firstlogin", middleware.RequireOwnCPF(), handlers.GetFirstLogin)
-			citizen.PUT("/:cpf/firstlogin", middleware.RequireOwnCPF(), handlers.UpdateFirstLogin)
-			citizen.GET("/:cpf/optin", middleware.RequireOwnCPF(), handlers.GetOptIn)
-			citizen.PUT("/:cpf/optin", middleware.RequireOwnCPF(), handlers.UpdateOptIn)
-			citizen.POST("/:cpf/phone/validate", middleware.RequireOwnCPF(), handlers.ValidatePhoneVerification)
-			citizen.GET("/:cpf/legal-entities", middleware.RequireOwnCPF(), handlers.GetLegalEntities)
-			citizen.GET("/:cpf/pets", middleware.RequireOwnCPF(), handlers.GetPets)
-			citizen.POST("/:cpf/pets", middleware.RequireOwnCPF(), handlers.RegisterPet)
-			citizen.GET("/:cpf/pets/:pet_id", middleware.RequireOwnCPF(), handlers.GetPet)
-			citizen.GET("/:cpf/pets/stats", middleware.RequireOwnCPF(), handlers.GetPetStats)
+			// GET endpoints: own CPF or service account (superapp, app-eai-agent)
+			citizen.GET("/:cpf", middleware.RequireOwnCPFOrServiceAccount("superapp", "app-eai-agent"), handlers.GetCitizenData)
+			citizen.GET("/:cpf/wallet", middleware.RequireOwnCPFOrServiceAccount("superapp", "app-eai-agent"), handlers.GetCitizenWallet)
+			citizen.GET("/:cpf/maintenance-request", middleware.RequireOwnCPFOrServiceAccount("superapp", "app-eai-agent"), handlers.GetMaintenanceRequests)
+			// PUT/POST endpoints: own CPF or service account (superapp only)
+			citizen.PUT("/:cpf/address", middleware.RequireOwnCPFOrServiceAccount("superapp"), handlers.UpdateSelfDeclaredAddress)
+			citizen.PUT("/:cpf/phone", middleware.RequireOwnCPFOrServiceAccount("superapp"), handlers.UpdateSelfDeclaredPhone)
+			citizen.PUT("/:cpf/email", middleware.RequireOwnCPFOrServiceAccount("superapp"), handlers.UpdateSelfDeclaredEmail)
+			citizen.PUT("/:cpf/ethnicity", middleware.RequireOwnCPFOrServiceAccount("superapp"), handlers.UpdateSelfDeclaredRaca)
+			citizen.PUT("/:cpf/exhibition-name", middleware.RequireOwnCPFOrServiceAccount("superapp"), handlers.UpdateSelfDeclaredNomeExibicao)
+			citizen.PUT("/:cpf/gender", middleware.RequireOwnCPFOrServiceAccount("superapp"), handlers.UpdateSelfDeclaredGenero)
+			citizen.PUT("/:cpf/family-income", middleware.RequireOwnCPFOrServiceAccount("superapp"), handlers.UpdateSelfDeclaredRendaFamiliar)
+			citizen.PUT("/:cpf/education", middleware.RequireOwnCPFOrServiceAccount("superapp"), handlers.UpdateSelfDeclaredEscolaridade)
+			citizen.PUT("/:cpf/disability", middleware.RequireOwnCPFOrServiceAccount("superapp"), handlers.UpdateSelfDeclaredDeficiencia)
+			citizen.GET("/:cpf/firstlogin", middleware.RequireOwnCPFOrServiceAccount("superapp", "app-eai-agent"), handlers.GetFirstLogin)
+			citizen.PUT("/:cpf/firstlogin", middleware.RequireOwnCPFOrServiceAccount("superapp"), handlers.UpdateFirstLogin)
+			citizen.GET("/:cpf/optin", middleware.RequireOwnCPFOrServiceAccount("superapp", "app-eai-agent"), handlers.GetOptIn)
+			citizen.PUT("/:cpf/optin", middleware.RequireOwnCPFOrServiceAccount("superapp"), handlers.UpdateOptIn)
+			citizen.POST("/:cpf/phone/validate", middleware.RequireOwnCPFOrServiceAccount("superapp"), handlers.ValidatePhoneVerification)
+			citizen.GET("/:cpf/legal-entities", middleware.RequireOwnCPFOrServiceAccount("superapp", "app-eai-agent"), handlers.GetLegalEntities)
+			citizen.GET("/:cpf/pets", middleware.RequireOwnCPFOrServiceAccount("superapp", "app-eai-agent"), handlers.GetPets)
+			citizen.POST("/:cpf/pets", middleware.RequireOwnCPFOrServiceAccount("superapp"), handlers.RegisterPet)
+			citizen.GET("/:cpf/pets/:pet_id", middleware.RequireOwnCPFOrServiceAccount("superapp", "app-eai-agent"), handlers.GetPet)
+			citizen.GET("/:cpf/pets/stats", middleware.RequireOwnCPFOrServiceAccount("superapp", "app-eai-agent"), handlers.GetPetStats)
 
 			// Avatar endpoints
-			citizen.GET("/:cpf/avatar", middleware.RequireOwnCPF(), handlers.GetUserAvatar)
-			citizen.PUT("/:cpf/avatar", middleware.RequireOwnCPF(), handlers.UpdateUserAvatar)
+			citizen.GET("/:cpf/avatar", middleware.RequireOwnCPFOrServiceAccount("superapp", "app-eai-agent"), handlers.GetUserAvatar)
+			citizen.PUT("/:cpf/avatar", middleware.RequireOwnCPFOrServiceAccount("superapp"), handlers.UpdateUserAvatar)
 		}
 
 		// Public citizen endpoints (no auth required)
@@ -240,9 +241,9 @@ func main() {
 			phoneGroup.GET("/:phone_number/beta-status", betaGroupHandlers.GetBetaStatus)
 		}
 
-		// Phone routes (protected)
+		// Phone routes (protected — service account only)
 		protectedPhoneGroup := v1.Group("/phone")
-		protectedPhoneGroup.Use(middleware.AuthMiddleware())
+		protectedPhoneGroup.Use(middleware.AuthMiddleware(), middleware.RequireServiceAccount("superapp", "app-sms-gateway", "app-notification"))
 		{
 			protectedPhoneGroup.GET("/:phone_number/citizen", phoneHandlers.GetCitizenByPhone)
 			protectedPhoneGroup.POST("/:phone_number/validate-registration", phoneHandlers.ValidateRegistration)
@@ -300,9 +301,9 @@ func main() {
 			cnaes.GET("", cnaeHandlers.ListCNAEs)
 		}
 
-		// Legal entity routes (protected)
+		// Legal entity routes (protected — service account only)
 		legalEntity := v1.Group("/legal-entity")
-		legalEntity.Use(middleware.AuthMiddleware())
+		legalEntity.Use(middleware.AuthMiddleware(), middleware.RequireServiceAccount("superapp", "app-eai-agent"))
 		{
 			legalEntity.GET("/:cnpj", handlers.GetLegalEntityByCNPJ)
 		}
@@ -331,9 +332,9 @@ func main() {
 			citizenPreferences.PATCH("/categories/:category_id", notificationPreferencesHandlers.UpdateCitizenCategoryPreference)
 		}
 
-		// Phone notification preferences routes (admin only)
+		// Phone notification preferences routes (service account only)
 		phonePreferences := v1.Group("/phone/:phone_number/notification-preferences")
-		phonePreferences.Use(middleware.AuthMiddleware(), middleware.RequireAdmin())
+		phonePreferences.Use(middleware.AuthMiddleware(), middleware.RequireServiceAccount("app-notification"))
 		{
 			phonePreferences.GET("", notificationPreferencesHandlers.GetPhonePreferences)
 			phonePreferences.PUT("", notificationPreferencesHandlers.UpdatePhonePreferences)

--- a/internal/handlers/citizen_helpers_test.go
+++ b/internal/handlers/citizen_helpers_test.go
@@ -23,12 +23,12 @@ func TestBuildAddressString(t *testing.T) {
 		{
 			name: "complete address with all fields",
 			endereco: &models.EnderecoPrincipal{
-				Logradouro: strPtr("Rua das Flores"),
-				Numero:     strPtr("123"),
+				Logradouro:  strPtr("Rua das Flores"),
+				Numero:      strPtr("123"),
 				Complemento: strPtr("Apto 401"),
-				Bairro:     strPtr("Centro"),
-				Municipio:  strPtr("Rio de Janeiro"),
-				Estado:     strPtr("RJ"),
+				Bairro:      strPtr("Centro"),
+				Municipio:   strPtr("Rio de Janeiro"),
+				Estado:      strPtr("RJ"),
 			},
 			expected: "Rua das Flores, 123, Apto 401, Centro, Rio de Janeiro, RJ",
 		},

--- a/internal/middleware/auth.go
+++ b/internal/middleware/auth.go
@@ -245,5 +245,106 @@ func IsAdmin(c *gin.Context) (bool, error) {
 	return false, nil
 }
 
+// RequireServiceAccount ensures the caller is either:
+//   - a Keycloak service account from one of the allowed client IDs, OR
+//   - a human admin (rmi-admin role — admins can do anything)
+//
+// Usage: RequireServiceAccount("superapp", "app-eai-agent")
+func RequireServiceAccount(clientIDs ...string) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		claims, exists := c.Get("claims")
+		if !exists {
+			c.JSON(http.StatusUnauthorized, gin.H{"error": "unauthorized"})
+			c.Abort()
+			return
+		}
+
+		jwtClaims, ok := claims.(*models.JWTClaims)
+		if !ok {
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "invalid claims"})
+			c.Abort()
+			return
+		}
+
+		// Admins bypass everything
+		for _, role := range jwtClaims.RealmAccess.Roles {
+			if role == config.AppConfig.AdminGroup {
+				c.Next()
+				return
+			}
+		}
+
+		// Must be a service account from one of the expected clients
+		isServiceAccount := strings.HasPrefix(jwtClaims.PreferredUsername, "service-account-")
+		isAllowedClient := false
+		for _, id := range clientIDs {
+			if jwtClaims.AZP == id {
+				isAllowedClient = true
+				break
+			}
+		}
+
+		if !isServiceAccount || !isAllowedClient {
+			c.JSON(http.StatusForbidden, gin.H{"error": "forbidden"})
+			c.Abort()
+			return
+		}
+
+		c.Next()
+	}
+}
+
+// RequireOwnCPFOrServiceAccount passes if the caller is:
+//   - a human admin (rmi-admin role), OR
+//   - a Keycloak service account from one of the allowed client IDs, OR
+//   - a regular user whose preferred_username matches the :cpf URL param
+//
+// Usage: RequireOwnCPFOrServiceAccount("superapp", "app-eai-agent")
+func RequireOwnCPFOrServiceAccount(clientIDs ...string) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		claims, exists := c.Get("claims")
+		if !exists {
+			c.JSON(http.StatusUnauthorized, gin.H{"error": "unauthorized"})
+			c.Abort()
+			return
+		}
+
+		jwtClaims, ok := claims.(*models.JWTClaims)
+		if !ok {
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "invalid claims"})
+			c.Abort()
+			return
+		}
+
+		// Admins bypass everything
+		for _, role := range jwtClaims.RealmAccess.Roles {
+			if role == config.AppConfig.AdminGroup {
+				c.Next()
+				return
+			}
+		}
+
+		// Service accounts from allowed clients bypass CPF check
+		if strings.HasPrefix(jwtClaims.PreferredUsername, "service-account-") {
+			for _, id := range clientIDs {
+				if jwtClaims.AZP == id {
+					c.Next()
+					return
+				}
+			}
+		}
+
+		// Regular users must be accessing their own CPF
+		requestedCPF := c.Param("cpf")
+		if jwtClaims.PreferredUsername == requestedCPF {
+			c.Next()
+			return
+		}
+
+		c.JSON(http.StatusForbidden, gin.H{"error": "forbidden"})
+		c.Abort()
+	}
+}
+
 // ErrAccessDenied is returned when access is denied
 var ErrAccessDenied = fmt.Errorf("access denied")

--- a/internal/middleware/auth.go
+++ b/internal/middleware/auth.go
@@ -332,6 +332,10 @@ func RequireOwnCPFOrServiceAccount(clientIDs ...string) gin.HandlerFunc {
 					return
 				}
 			}
+			// SA from a disallowed client — reject immediately
+			c.JSON(http.StatusForbidden, gin.H{"error": "forbidden"})
+			c.Abort()
+			return
 		}
 
 		// Regular users must be accessing their own CPF

--- a/internal/middleware/auth.go
+++ b/internal/middleware/auth.go
@@ -133,23 +133,7 @@ func RequireAdmin() gin.HandlerFunc {
 		}
 
 		// Check if user has admin role in RealmAccess or ResourceAccess.Superapp
-		isAdmin := false
-		for _, role := range jwtClaims.RealmAccess.Roles {
-			if role == config.AppConfig.AdminGroup {
-				isAdmin = true
-				break
-			}
-		}
-		if !isAdmin {
-			for _, role := range jwtClaims.ResourceAccess.Superapp.Roles {
-				if role == config.AppConfig.AdminGroup {
-					isAdmin = true
-					break
-				}
-			}
-		}
-
-		if !isAdmin {
+		if !isAdminClaims(jwtClaims) {
 			c.JSON(http.StatusForbidden, gin.H{"error": "Admin privileges required"})
 			c.Abort()
 			return
@@ -180,25 +164,8 @@ func RequireOwnCPF() gin.HandlerFunc {
 		requestedCPF := c.Param("cpf")
 		userCPF := jwtClaims.PreferredUsername
 
-		// Check if user is admin in RealmAccess or ResourceAccess.Superapp
-		isAdmin := false
-		for _, role := range jwtClaims.RealmAccess.Roles {
-			if role == config.AppConfig.AdminGroup {
-				isAdmin = true
-				break
-			}
-		}
-		if !isAdmin {
-			for _, role := range jwtClaims.ResourceAccess.Superapp.Roles {
-				if role == config.AppConfig.AdminGroup {
-					isAdmin = true
-					break
-				}
-			}
-		}
-
 		// Allow if user is admin or accessing their own data
-		if !isAdmin && requestedCPF != userCPF {
+		if !isAdminClaims(jwtClaims) && requestedCPF != userCPF {
 			c.JSON(http.StatusForbidden, gin.H{"error": "Access denied"})
 			c.Abort()
 			return
@@ -223,6 +190,22 @@ func ExtractCPFFromToken(c *gin.Context) (string, error) {
 	return jwtClaims.PreferredUsername, nil
 }
 
+// isAdminClaims reports whether the JWT claims carry the configured admin group
+// in either RealmAccess.Roles or ResourceAccess.Superapp.Roles.
+func isAdminClaims(jwtClaims *models.JWTClaims) bool {
+	for _, role := range jwtClaims.RealmAccess.Roles {
+		if role == config.AppConfig.AdminGroup {
+			return true
+		}
+	}
+	for _, role := range jwtClaims.ResourceAccess.Superapp.Roles {
+		if role == config.AppConfig.AdminGroup {
+			return true
+		}
+	}
+	return false
+}
+
 // IsAdmin checks if the user has admin privileges
 func IsAdmin(c *gin.Context) (bool, error) {
 	claims, exists := c.Get("claims")
@@ -235,43 +218,34 @@ func IsAdmin(c *gin.Context) (bool, error) {
 		return false, fmt.Errorf("invalid claims type")
 	}
 
-	// Check if user has admin role
-	for _, role := range jwtClaims.RealmAccess.Roles {
-		if role == config.AppConfig.AdminGroup {
-			return true, nil
-		}
-	}
-
-	return false, nil
+	return isAdminClaims(jwtClaims), nil
 }
 
 // RequireServiceAccount ensures the caller is either:
 //   - a Keycloak service account from one of the allowed client IDs, OR
-//   - a human admin (rmi-admin role — admins can do anything)
+//   - a human admin in the configured admin group (admins can do anything)
 //
 // Usage: RequireServiceAccount("superapp", "app-eai-agent")
 func RequireServiceAccount(clientIDs ...string) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		claims, exists := c.Get("claims")
 		if !exists {
-			c.JSON(http.StatusUnauthorized, gin.H{"error": "unauthorized"})
+			c.JSON(http.StatusUnauthorized, gin.H{"error": "Claims not found"})
 			c.Abort()
 			return
 		}
 
 		jwtClaims, ok := claims.(*models.JWTClaims)
 		if !ok {
-			c.JSON(http.StatusInternalServerError, gin.H{"error": "invalid claims"})
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "Invalid claims type"})
 			c.Abort()
 			return
 		}
 
-		// Admins bypass everything
-		for _, role := range jwtClaims.RealmAccess.Roles {
-			if role == config.AppConfig.AdminGroup {
-				c.Next()
-				return
-			}
+		// Admins bypass everything (checked in both RealmAccess and ResourceAccess.Superapp)
+		if isAdminClaims(jwtClaims) {
+			c.Next()
+			return
 		}
 
 		// Must be a service account from one of the expected clients
@@ -295,7 +269,7 @@ func RequireServiceAccount(clientIDs ...string) gin.HandlerFunc {
 }
 
 // RequireOwnCPFOrServiceAccount passes if the caller is:
-//   - a human admin (rmi-admin role), OR
+//   - a human admin in the configured admin group, OR
 //   - a Keycloak service account from one of the allowed client IDs, OR
 //   - a regular user whose preferred_username matches the :cpf URL param
 //
@@ -304,24 +278,22 @@ func RequireOwnCPFOrServiceAccount(clientIDs ...string) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		claims, exists := c.Get("claims")
 		if !exists {
-			c.JSON(http.StatusUnauthorized, gin.H{"error": "unauthorized"})
+			c.JSON(http.StatusUnauthorized, gin.H{"error": "Claims not found"})
 			c.Abort()
 			return
 		}
 
 		jwtClaims, ok := claims.(*models.JWTClaims)
 		if !ok {
-			c.JSON(http.StatusInternalServerError, gin.H{"error": "invalid claims"})
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "Invalid claims type"})
 			c.Abort()
 			return
 		}
 
-		// Admins bypass everything
-		for _, role := range jwtClaims.RealmAccess.Roles {
-			if role == config.AppConfig.AdminGroup {
-				c.Next()
-				return
-			}
+		// Admins bypass everything (checked in both RealmAccess and ResourceAccess.Superapp)
+		if isAdminClaims(jwtClaims) {
+			c.Next()
+			return
 		}
 
 		// Service accounts from allowed clients bypass CPF check

--- a/internal/middleware/auth.go
+++ b/internal/middleware/auth.go
@@ -248,8 +248,9 @@ func RequireServiceAccount(clientIDs ...string) gin.HandlerFunc {
 			return
 		}
 
-		// Must be a service account from one of the expected clients
-		isServiceAccount := strings.HasPrefix(jwtClaims.PreferredUsername, "service-account-")
+		// Must be a service account from one of the expected clients.
+		// We require preferred_username == "service-account-"+AZP (Keycloak convention)
+		// in addition to AZP matching an allowed client ID, preventing username spoofing.
 		isAllowedClient := false
 		for _, id := range clientIDs {
 			if jwtClaims.AZP == id {
@@ -257,9 +258,10 @@ func RequireServiceAccount(clientIDs ...string) gin.HandlerFunc {
 				break
 			}
 		}
+		isServiceAccount := jwtClaims.PreferredUsername == "service-account-"+jwtClaims.AZP
 
 		if !isServiceAccount || !isAllowedClient {
-			c.JSON(http.StatusForbidden, gin.H{"error": "forbidden"})
+			c.JSON(http.StatusForbidden, gin.H{"error": "Service account not authorized"})
 			c.Abort()
 			return
 		}
@@ -296,8 +298,10 @@ func RequireOwnCPFOrServiceAccount(clientIDs ...string) gin.HandlerFunc {
 			return
 		}
 
-		// Service accounts from allowed clients bypass CPF check
-		if strings.HasPrefix(jwtClaims.PreferredUsername, "service-account-") {
+		// Service accounts from allowed clients bypass CPF check.
+		// We require preferred_username == "service-account-"+AZP (Keycloak convention)
+		// in addition to AZP matching an allowed client ID, preventing username spoofing.
+		if jwtClaims.PreferredUsername == "service-account-"+jwtClaims.AZP {
 			for _, id := range clientIDs {
 				if jwtClaims.AZP == id {
 					c.Next()
@@ -305,7 +309,7 @@ func RequireOwnCPFOrServiceAccount(clientIDs ...string) gin.HandlerFunc {
 				}
 			}
 			// SA from a disallowed client — reject immediately
-			c.JSON(http.StatusForbidden, gin.H{"error": "forbidden"})
+			c.JSON(http.StatusForbidden, gin.H{"error": "Service account not authorized"})
 			c.Abort()
 			return
 		}
@@ -317,7 +321,7 @@ func RequireOwnCPFOrServiceAccount(clientIDs ...string) gin.HandlerFunc {
 			return
 		}
 
-		c.JSON(http.StatusForbidden, gin.H{"error": "forbidden"})
+		c.JSON(http.StatusForbidden, gin.H{"error": "Access denied"})
 		c.Abort()
 	}
 }

--- a/internal/middleware/auth_test.go
+++ b/internal/middleware/auth_test.go
@@ -391,13 +391,28 @@ func injectClaims(claims *models.JWTClaims) gin.HandlerFunc {
 	}
 }
 
-// makeAdminClaims returns claims for a human admin (has adminGroup in RealmAccess.Roles).
+// makeAdminClaims returns claims for a human admin.
+// The admin role is populated in both RealmAccess.Roles and
+// ResourceAccess.Superapp.Roles because middleware accepts either shape.
 func makeAdminClaims() *models.JWTClaims {
 	c := &models.JWTClaims{
 		PreferredUsername: "admin-user",
 		AZP:               "some-client",
 	}
 	c.RealmAccess.Roles = []string{adminGroup}
+	c.ResourceAccess.Superapp.Roles = []string{adminGroup}
+	return c
+}
+
+// makeAdminClaimsResourceOnly returns claims where the admin role is present
+// only in ResourceAccess.Superapp.Roles (not in RealmAccess.Roles).
+// Used to verify that middleware correctly checks both sources.
+func makeAdminClaimsResourceOnly() *models.JWTClaims {
+	c := &models.JWTClaims{
+		PreferredUsername: "admin-user",
+		AZP:               "some-client",
+	}
+	c.ResourceAccess.Superapp.Roles = []string{adminGroup}
 	return c
 }
 
@@ -643,4 +658,39 @@ func TestRequireOwnCPFOrServiceAccount_NoClaims(t *testing.T) {
 
 	// Assert
 	assert.Equal(t, http.StatusUnauthorized, w.Code, "missing claims must return 401")
+}
+
+// TestRequireServiceAccount_AdminCallerViaResourceAccess verifies that an admin
+// whose role is only in ResourceAccess.Superapp.Roles (not RealmAccess.Roles) is
+// still allowed through RequireServiceAccount.
+func TestRequireServiceAccount_AdminCallerViaResourceAccess(t *testing.T) {
+	// Arrange — admin role only in ResourceAccess.Superapp.Roles
+	router := buildRouter("", injectClaims(makeAdminClaimsResourceOnly()), RequireServiceAccount("superapp"))
+	req, _ := http.NewRequest(http.MethodGet, "/test", nil)
+	w := httptest.NewRecorder()
+
+	// Act
+	router.ServeHTTP(w, req)
+
+	// Assert
+	assert.Equal(t, http.StatusOK, w.Code, "admin via ResourceAccess.Superapp.Roles must bypass RequireServiceAccount")
+}
+
+// TestRequireOwnCPFOrServiceAccount_AdminCallerViaResourceAccess verifies that an
+// admin whose role is only in ResourceAccess.Superapp.Roles (not RealmAccess.Roles)
+// is still allowed through RequireOwnCPFOrServiceAccount.
+func TestRequireOwnCPFOrServiceAccount_AdminCallerViaResourceAccess(t *testing.T) {
+	// Arrange — admin role only in ResourceAccess.Superapp.Roles, accessing another CPF
+	router := buildRouter("/citizen/:cpf/data",
+		injectClaims(makeAdminClaimsResourceOnly()),
+		RequireOwnCPFOrServiceAccount("superapp"),
+	)
+	req, _ := http.NewRequest(http.MethodGet, "/citizen/99999999999/data", nil)
+	w := httptest.NewRecorder()
+
+	// Act
+	router.ServeHTTP(w, req)
+
+	// Assert
+	assert.Equal(t, http.StatusOK, w.Code, "admin via ResourceAccess.Superapp.Roles must bypass RequireOwnCPFOrServiceAccount")
 }

--- a/internal/middleware/auth_test.go
+++ b/internal/middleware/auth_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/prefeitura-rio/app-rmi/internal/config"
 	"github.com/prefeitura-rio/app-rmi/internal/logging"
 	"github.com/prefeitura-rio/app-rmi/internal/models"
+	"github.com/stretchr/testify/assert"
 )
 
 func init() {
@@ -357,4 +358,289 @@ func TestMin(t *testing.T) {
 			}
 		})
 	}
+}
+
+// ---------------------------------------------------------------------------
+// Helpers for RequireServiceAccount / RequireOwnCPFOrServiceAccount tests
+// ---------------------------------------------------------------------------
+
+// adminGroup is the value set in init() — must match config.AppConfig.AdminGroup.
+const adminGroup = "go:admin"
+
+// buildRouter creates a gin.Engine with the given middleware chain and a dummy
+// GET /test handler that always returns 200. The optional routePath lets callers
+// register a parameterised route (e.g. "/citizen/:cpf/data").
+func buildRouter(routePath string, middlewares ...gin.HandlerFunc) *gin.Engine {
+	r := gin.New()
+	path := routePath
+	if path == "" {
+		path = "/test"
+	}
+	r.GET(path, append(middlewares, func(c *gin.Context) {
+		c.JSON(http.StatusOK, gin.H{"message": "ok"})
+	})...)
+	return r
+}
+
+// injectClaims returns a gin.HandlerFunc that stores the given claims in the
+// context under the "claims" key, mimicking what AuthMiddleware does.
+func injectClaims(claims *models.JWTClaims) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		c.Set("claims", claims)
+		c.Next()
+	}
+}
+
+// makeAdminClaims returns claims for a human admin (has adminGroup in RealmAccess.Roles).
+func makeAdminClaims() *models.JWTClaims {
+	c := &models.JWTClaims{
+		PreferredUsername: "admin-user",
+		AZP:               "some-client",
+	}
+	c.RealmAccess.Roles = []string{adminGroup}
+	return c
+}
+
+// makeSAClaims returns claims for a Keycloak service account from clientID.
+func makeSAClaims(clientID string) *models.JWTClaims {
+	return &models.JWTClaims{
+		PreferredUsername: "service-account-" + clientID,
+		AZP:               clientID,
+	}
+}
+
+// makeUserClaims returns claims for a regular (non-SA, non-admin) user.
+func makeUserClaims(preferredUsername string) *models.JWTClaims {
+	return &models.JWTClaims{
+		PreferredUsername: preferredUsername,
+		AZP:               "some-client",
+	}
+}
+
+// ---------------------------------------------------------------------------
+// RequireServiceAccount tests
+// ---------------------------------------------------------------------------
+
+// TestRequireServiceAccount_AdminCaller verifies that a caller with the admin
+// role in realm_access.roles is always allowed through, regardless of azp.
+func TestRequireServiceAccount_AdminCaller(t *testing.T) {
+	// Arrange
+	router := buildRouter("", injectClaims(makeAdminClaims()), RequireServiceAccount("superapp"))
+	req, _ := http.NewRequest(http.MethodGet, "/test", nil)
+	w := httptest.NewRecorder()
+
+	// Act
+	router.ServeHTTP(w, req)
+
+	// Assert
+	assert.Equal(t, http.StatusOK, w.Code, "admin caller must bypass RequireServiceAccount")
+}
+
+// TestRequireServiceAccount_ValidSACorrectClient verifies that a service account
+// from the expected client is allowed through.
+func TestRequireServiceAccount_ValidSACorrectClient(t *testing.T) {
+	// Arrange
+	router := buildRouter("", injectClaims(makeSAClaims("superapp")), RequireServiceAccount("superapp"))
+	req, _ := http.NewRequest(http.MethodGet, "/test", nil)
+	w := httptest.NewRecorder()
+
+	// Act
+	router.ServeHTTP(w, req)
+
+	// Assert
+	assert.Equal(t, http.StatusOK, w.Code, "valid SA from correct client must be allowed")
+}
+
+// TestRequireServiceAccount_ValidSAWrongClient verifies that a service account
+// from a different client is rejected with 403.
+func TestRequireServiceAccount_ValidSAWrongClient(t *testing.T) {
+	// Arrange
+	router := buildRouter("", injectClaims(makeSAClaims("other-client")), RequireServiceAccount("superapp"))
+	req, _ := http.NewRequest(http.MethodGet, "/test", nil)
+	w := httptest.NewRecorder()
+
+	// Act
+	router.ServeHTTP(w, req)
+
+	// Assert
+	assert.Equal(t, http.StatusForbidden, w.Code, "SA from wrong client must be rejected")
+}
+
+// TestRequireServiceAccount_NotSACorrectAZP verifies that a regular user whose
+// azp matches the allowed client ID is still rejected (no service-account- prefix).
+func TestRequireServiceAccount_NotSACorrectAZP(t *testing.T) {
+	// Arrange — preferred_username does NOT start with "service-account-"
+	claims := &models.JWTClaims{
+		PreferredUsername: "regular-user",
+		AZP:               "superapp",
+	}
+	router := buildRouter("", injectClaims(claims), RequireServiceAccount("superapp"))
+	req, _ := http.NewRequest(http.MethodGet, "/test", nil)
+	w := httptest.NewRecorder()
+
+	// Act
+	router.ServeHTTP(w, req)
+
+	// Assert
+	assert.Equal(t, http.StatusForbidden, w.Code, "non-SA caller must be rejected even with correct azp")
+}
+
+// TestRequireServiceAccount_NoClaims verifies that a request with no claims in
+// context is rejected with 401.
+func TestRequireServiceAccount_NoClaims(t *testing.T) {
+	// Arrange — no injectClaims middleware, so context has no "claims" key
+	router := buildRouter("", RequireServiceAccount("superapp"))
+	req, _ := http.NewRequest(http.MethodGet, "/test", nil)
+	w := httptest.NewRecorder()
+
+	// Act
+	router.ServeHTTP(w, req)
+
+	// Assert
+	assert.Equal(t, http.StatusUnauthorized, w.Code, "missing claims must return 401")
+}
+
+// TestRequireServiceAccount_MultipleClientIDs_MatchesSecond verifies that when
+// multiple client IDs are allowed, a caller matching the second one is accepted.
+func TestRequireServiceAccount_MultipleClientIDs_MatchesSecond(t *testing.T) {
+	// Arrange — SA from "app-eai-agent", allowed list is ["superapp", "app-eai-agent"]
+	router := buildRouter("",
+		injectClaims(makeSAClaims("app-eai-agent")),
+		RequireServiceAccount("superapp", "app-eai-agent"),
+	)
+	req, _ := http.NewRequest(http.MethodGet, "/test", nil)
+	w := httptest.NewRecorder()
+
+	// Act
+	router.ServeHTTP(w, req)
+
+	// Assert
+	assert.Equal(t, http.StatusOK, w.Code, "SA matching second allowed client must be accepted")
+}
+
+// TestRequireServiceAccount_MultipleClientIDs_MatchesNone verifies that a SA
+// whose azp does not match any of the allowed client IDs is rejected with 403.
+func TestRequireServiceAccount_MultipleClientIDs_MatchesNone(t *testing.T) {
+	// Arrange — SA from "unknown-client", allowed list is ["superapp", "app-eai-agent"]
+	router := buildRouter("",
+		injectClaims(makeSAClaims("unknown-client")),
+		RequireServiceAccount("superapp", "app-eai-agent"),
+	)
+	req, _ := http.NewRequest(http.MethodGet, "/test", nil)
+	w := httptest.NewRecorder()
+
+	// Act
+	router.ServeHTTP(w, req)
+
+	// Assert
+	assert.Equal(t, http.StatusForbidden, w.Code, "SA matching no allowed client must be rejected")
+}
+
+// ---------------------------------------------------------------------------
+// RequireOwnCPFOrServiceAccount tests
+// ---------------------------------------------------------------------------
+
+// TestRequireOwnCPFOrServiceAccount_AdminCaller verifies that an admin is always
+// allowed through, regardless of the :cpf param or azp.
+func TestRequireOwnCPFOrServiceAccount_AdminCaller(t *testing.T) {
+	// Arrange
+	router := buildRouter("/citizen/:cpf/data",
+		injectClaims(makeAdminClaims()),
+		RequireOwnCPFOrServiceAccount("superapp"),
+	)
+	req, _ := http.NewRequest(http.MethodGet, "/citizen/99999999999/data", nil)
+	w := httptest.NewRecorder()
+
+	// Act
+	router.ServeHTTP(w, req)
+
+	// Assert
+	assert.Equal(t, http.StatusOK, w.Code, "admin caller must bypass RequireOwnCPFOrServiceAccount")
+}
+
+// TestRequireOwnCPFOrServiceAccount_ValidSAAllowedClient verifies that a service
+// account from an allowed client can access any CPF.
+func TestRequireOwnCPFOrServiceAccount_ValidSAAllowedClient(t *testing.T) {
+	// Arrange
+	router := buildRouter("/citizen/:cpf/data",
+		injectClaims(makeSAClaims("superapp")),
+		RequireOwnCPFOrServiceAccount("superapp", "app-eai-agent"),
+	)
+	req, _ := http.NewRequest(http.MethodGet, "/citizen/12345678901/data", nil)
+	w := httptest.NewRecorder()
+
+	// Act
+	router.ServeHTTP(w, req)
+
+	// Assert
+	assert.Equal(t, http.StatusOK, w.Code, "SA from allowed client must be accepted")
+}
+
+// TestRequireOwnCPFOrServiceAccount_ValidSADisallowedClient verifies that a
+// service account from a client NOT in the allowed list is rejected with 403.
+func TestRequireOwnCPFOrServiceAccount_ValidSADisallowedClient(t *testing.T) {
+	// Arrange — SA from "app-sms-gateway", allowed list is ["superapp"]
+	router := buildRouter("/citizen/:cpf/data",
+		injectClaims(makeSAClaims("app-sms-gateway")),
+		RequireOwnCPFOrServiceAccount("superapp"),
+	)
+	req, _ := http.NewRequest(http.MethodGet, "/citizen/12345678901/data", nil)
+	w := httptest.NewRecorder()
+
+	// Act
+	router.ServeHTTP(w, req)
+
+	// Assert
+	assert.Equal(t, http.StatusForbidden, w.Code, "SA from disallowed client must be rejected")
+}
+
+// TestRequireOwnCPFOrServiceAccount_CitizenAccessesOwnCPF verifies that a
+// regular citizen whose preferred_username matches the :cpf param is allowed.
+func TestRequireOwnCPFOrServiceAccount_CitizenAccessesOwnCPF(t *testing.T) {
+	// Arrange — preferred_username == CPF in URL
+	router := buildRouter("/citizen/:cpf/data",
+		injectClaims(makeUserClaims("12345678901")),
+		RequireOwnCPFOrServiceAccount("superapp"),
+	)
+	req, _ := http.NewRequest(http.MethodGet, "/citizen/12345678901/data", nil)
+	w := httptest.NewRecorder()
+
+	// Act
+	router.ServeHTTP(w, req)
+
+	// Assert
+	assert.Equal(t, http.StatusOK, w.Code, "citizen accessing own CPF must be allowed")
+}
+
+// TestRequireOwnCPFOrServiceAccount_CitizenAccessesOtherCPF verifies that a
+// regular citizen trying to access another citizen's CPF is rejected with 403.
+func TestRequireOwnCPFOrServiceAccount_CitizenAccessesOtherCPF(t *testing.T) {
+	// Arrange — preferred_username != CPF in URL, not SA, not admin
+	router := buildRouter("/citizen/:cpf/data",
+		injectClaims(makeUserClaims("12345678901")),
+		RequireOwnCPFOrServiceAccount("superapp"),
+	)
+	req, _ := http.NewRequest(http.MethodGet, "/citizen/99999999999/data", nil)
+	w := httptest.NewRecorder()
+
+	// Act
+	router.ServeHTTP(w, req)
+
+	// Assert
+	assert.Equal(t, http.StatusForbidden, w.Code, "citizen accessing another's CPF must be rejected")
+}
+
+// TestRequireOwnCPFOrServiceAccount_NoClaims verifies that a request with no
+// claims in context is rejected with 401.
+func TestRequireOwnCPFOrServiceAccount_NoClaims(t *testing.T) {
+	// Arrange — no injectClaims middleware
+	router := buildRouter("/citizen/:cpf/data", RequireOwnCPFOrServiceAccount("superapp"))
+	req, _ := http.NewRequest(http.MethodGet, "/citizen/12345678901/data", nil)
+	w := httptest.NewRecorder()
+
+	// Act
+	router.ServeHTTP(w, req)
+
+	// Assert
+	assert.Equal(t, http.StatusUnauthorized, w.Code, "missing claims must return 401")
 }

--- a/internal/middleware/auth_test.go
+++ b/internal/middleware/auth_test.go
@@ -364,8 +364,8 @@ func TestMin(t *testing.T) {
 // Helpers for RequireServiceAccount / RequireOwnCPFOrServiceAccount tests
 // ---------------------------------------------------------------------------
 
-// adminGroup is the value set in init() — must match config.AppConfig.AdminGroup.
-const adminGroup = "go:admin"
+// adminGroup returns the configured admin group so tests stay in sync with config.
+func adminGroup() string { return config.AppConfig.AdminGroup }
 
 // buildRouter creates a gin.Engine with the given middleware chain and a dummy
 // GET /test handler that always returns 200. The optional routePath lets callers
@@ -399,8 +399,8 @@ func makeAdminClaims() *models.JWTClaims {
 		PreferredUsername: "admin-user",
 		AZP:               "some-client",
 	}
-	c.RealmAccess.Roles = []string{adminGroup}
-	c.ResourceAccess.Superapp.Roles = []string{adminGroup}
+	c.RealmAccess.Roles = []string{adminGroup()}
+	c.ResourceAccess.Superapp.Roles = []string{adminGroup()}
 	return c
 }
 
@@ -412,7 +412,7 @@ func makeAdminClaimsResourceOnly() *models.JWTClaims {
 		PreferredUsername: "admin-user",
 		AZP:               "some-client",
 	}
-	c.ResourceAccess.Superapp.Roles = []string{adminGroup}
+	c.ResourceAccess.Superapp.Roles = []string{adminGroup()}
 	return c
 }
 


### PR DESCRIPTION
## Summary

- Adds `RequireServiceAccount(clientIDs ...string)` middleware — validates that the caller is a specific Keycloak service account (checks `preferred_username` prefix + `azp` claim)
- Adds `RequireOwnCPFOrServiceAccount(clientIDs ...string)` middleware — passes if admin, allowed SA, or own CPF; explicitly rejects disallowed SAs (no fallthrough)
- Updates route registrations in `cmd/api/main.go` per client→endpoint mapping (superapp, app-eai-agent, app-sms-gateway, app-notification)
- 13 unit tests added in `internal/middleware/auth_test.go`, all passing

## Phase

RMI Service Account Migration — Phase 2 (middleware + routes). Phases 1/3/4 depend on Keycloak client creation.