### PR TITLE
feat: add CPF-secretaria mapping CRUD and query endpoint

### DIFF
--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -115,6 +115,8 @@ func main() {
 	// Initialize department service for department/UA queries
 	services.InitDepartmentService()
 
+	services.InitCPFSecretariaService()
+
 	// Initialize CF rate limiter for CF lookup requests
 	services.InitCFRateLimiter(config.AppConfig.CFLookupGlobalRateLimit, observability.Logger())
 
@@ -278,6 +280,16 @@ func main() {
 
 			// Cache management
 			adminGroup.POST("/cache/read", handlers.ReadCacheKey)
+
+			adminGroup.GET("/cpf-secretaria/:cpf", handlers.AdminListCPFSecretaria)
+			adminGroup.POST("/cpf-secretaria/:cpf", handlers.AdminAddCPFSecretaria)
+			adminGroup.DELETE("/cpf-secretaria/:cpf/:cd_ua", handlers.AdminRemoveCPFSecretaria)
+		}
+
+		cpfSecretariaGroup := v1.Group("/cpf-secretaria")
+		cpfSecretariaGroup.Use(middleware.AuthMiddleware())
+		{
+			cpfSecretariaGroup.GET("/:cpf", handlers.GetCPFSecretarias)
 		}
 
 		// Config routes (public)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -57,6 +57,7 @@ type Config struct {
 	DepartmentCollection           string `json:"mongo_department_collection"`
 	NotificationCategoryCollection string `json:"mongo_notification_category_collection"`
 	CNAECollection                 string `json:"mongo_cnae_collection"`
+	CPFSecretariaCollection        string `json:"mongo_cpf_secretaria_collection"`
 
 	// Phone verification configuration
 	PhoneVerificationTTL time.Duration `json:"phone_verification_ttl"`
@@ -368,6 +369,7 @@ func LoadConfig() error {
 		DepartmentCollection:           departmentCollection,
 		NotificationCategoryCollection: notificationCategoryCollection,
 		CNAECollection:                 cnaeCollection,
+		CPFSecretariaCollection:        getEnvOrDefault("MONGODB_CPF_SECRETARIA_COLLECTION", "cpf_secretaria_mappings"),
 
 		// Phone verification configuration
 		PhoneVerificationTTL:          phoneVerificationTTL,

--- a/internal/handlers/common_test.go
+++ b/internal/handlers/common_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/prefeitura-rio/app-rmi/internal/config"
+	"github.com/prefeitura-rio/app-rmi/internal/services"
 	"go.uber.org/zap"
 )
 
@@ -52,6 +53,7 @@ func setupTestEnvironment() {
 			"MONGODB_PETS_SELF_REGISTERED_COLLECTION":  "pets_self_registered",
 			"MONGODB_NOTIFICATION_CATEGORY_COLLECTION": "notification_categories",
 			"MONGODB_USER_CONFIG_COLLECTION":           "user_config",
+			"MONGODB_CPF_SECRETARIA_COLLECTION":        "cpf_secretaria_test",
 		}
 		for key, defaultValue := range collections {
 			if os.Getenv(key) == "" {
@@ -102,6 +104,7 @@ func setupTestEnvironment() {
 		// lock in ensureIndexes (called by InitMongoDB) can be exercised in tests.
 		config.InitRedis()
 		config.InitMongoDB()
+		services.InitCPFSecretariaService()
 
 		zap.L().Info("Test environment initialized for handlers package")
 	})

--- a/internal/handlers/cpf_secretaria_handlers.go
+++ b/internal/handlers/cpf_secretaria_handlers.go
@@ -1,0 +1,200 @@
+package handlers
+
+import (
+	"fmt"
+	"net/http"
+	"strings"
+
+	"github.com/gin-gonic/gin"
+	"github.com/prefeitura-rio/app-rmi/internal/middleware"
+	"github.com/prefeitura-rio/app-rmi/internal/models"
+	"github.com/prefeitura-rio/app-rmi/internal/services"
+)
+
+// AdminListCPFSecretaria godoc
+// @Summary Listar vínculos CPF-Secretaria
+// @Description Retorna todos os vínculos de secretaria associados a um CPF na base de apoio.
+// @Tags admin,cpf-secretaria
+// @Produce json
+// @Param cpf path string true "CPF do usuário (11 dígitos)"
+// @Security BearerAuth
+// @Success 200 {object} models.CPFSecretariaListResponse
+// @Failure 401 {object} ErrorResponse
+// @Failure 403 {object} ErrorResponse
+// @Failure 500 {object} ErrorResponse
+// @Router /admin/cpf-secretaria/{cpf} [get]
+func AdminListCPFSecretaria(c *gin.Context) {
+	cpf := c.Param("cpf")
+	if err := validateCPFParam(cpf); err != nil {
+		c.JSON(http.StatusBadRequest, ErrorResponse{Error: err.Error()})
+		return
+	}
+
+	if services.CPFSecretariaServiceInstance == nil {
+		c.JSON(http.StatusInternalServerError, ErrorResponse{Error: "service unavailable"})
+		return
+	}
+
+	mappings, err := services.CPFSecretariaServiceInstance.ListByCPF(c.Request.Context(), cpf)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, ErrorResponse{Error: err.Error()})
+		return
+	}
+
+	responses := make([]models.CPFSecretariaResponse, 0, len(mappings))
+	for _, m := range mappings {
+		responses = append(responses, m.ToResponse())
+	}
+
+	c.JSON(http.StatusOK, models.CPFSecretariaListResponse{
+		CPF:      cpf,
+		Mappings: responses,
+	})
+}
+
+// AdminAddCPFSecretaria godoc
+// @Summary Adicionar vínculo CPF-Secretaria
+// @Description Vincula um CPF a uma secretaria (cd_ua SICI) na base de apoio. Um CPF pode ter múltiplos vínculos.
+// @Tags admin,cpf-secretaria
+// @Accept json
+// @Produce json
+// @Param cpf path string true "CPF do usuário (11 dígitos)"
+// @Param data body models.AddCPFSecretariaRequest true "cd_ua da secretaria"
+// @Security BearerAuth
+// @Success 201 {object} models.CPFSecretariaResponse
+// @Failure 400 {object} ErrorResponse
+// @Failure 401 {object} ErrorResponse
+// @Failure 403 {object} ErrorResponse
+// @Failure 409 {object} ErrorResponse
+// @Failure 500 {object} ErrorResponse
+// @Router /admin/cpf-secretaria/{cpf} [post]
+func AdminAddCPFSecretaria(c *gin.Context) {
+	cpf := c.Param("cpf")
+	if err := validateCPFParam(cpf); err != nil {
+		c.JSON(http.StatusBadRequest, ErrorResponse{Error: err.Error()})
+		return
+	}
+
+	var req models.AddCPFSecretariaRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		c.JSON(http.StatusBadRequest, ErrorResponse{Error: "invalid request: " + err.Error()})
+		return
+	}
+	if strings.TrimSpace(req.CdUA) == "" {
+		c.JSON(http.StatusBadRequest, ErrorResponse{Error: "cd_ua is required"})
+		return
+	}
+
+	if services.CPFSecretariaServiceInstance == nil {
+		c.JSON(http.StatusInternalServerError, ErrorResponse{Error: "service unavailable"})
+		return
+	}
+
+	createdBy, _ := middleware.ExtractCPFFromToken(c)
+
+	mapping, err := services.CPFSecretariaServiceInstance.AddMapping(c.Request.Context(), cpf, req.CdUA, createdBy)
+	if err != nil {
+		if strings.Contains(err.Error(), "already exists") {
+			c.JSON(http.StatusConflict, ErrorResponse{Error: err.Error()})
+			return
+		}
+		c.JSON(http.StatusInternalServerError, ErrorResponse{Error: err.Error()})
+		return
+	}
+
+	c.JSON(http.StatusCreated, mapping.ToResponse())
+}
+
+// AdminRemoveCPFSecretaria godoc
+// @Summary Remover vínculo CPF-Secretaria
+// @Description Remove o vínculo entre um CPF e uma secretaria específica.
+// @Tags admin,cpf-secretaria
+// @Produce json
+// @Param cpf path string true "CPF do usuário (11 dígitos)"
+// @Param cd_ua path string true "Código da UA (SICI)"
+// @Security BearerAuth
+// @Success 204
+// @Failure 400 {object} ErrorResponse
+// @Failure 401 {object} ErrorResponse
+// @Failure 403 {object} ErrorResponse
+// @Failure 404 {object} ErrorResponse
+// @Failure 500 {object} ErrorResponse
+// @Router /admin/cpf-secretaria/{cpf}/{cd_ua} [delete]
+func AdminRemoveCPFSecretaria(c *gin.Context) {
+	cpf := c.Param("cpf")
+	cdUA := c.Param("cd_ua")
+
+	if err := validateCPFParam(cpf); err != nil {
+		c.JSON(http.StatusBadRequest, ErrorResponse{Error: err.Error()})
+		return
+	}
+	if strings.TrimSpace(cdUA) == "" {
+		c.JSON(http.StatusBadRequest, ErrorResponse{Error: "cd_ua is required"})
+		return
+	}
+
+	if services.CPFSecretariaServiceInstance == nil {
+		c.JSON(http.StatusInternalServerError, ErrorResponse{Error: "service unavailable"})
+		return
+	}
+
+	if err := services.CPFSecretariaServiceInstance.RemoveMapping(c.Request.Context(), cpf, cdUA); err != nil {
+		if strings.Contains(err.Error(), "not found") {
+			c.JSON(http.StatusNotFound, ErrorResponse{Error: err.Error()})
+			return
+		}
+		c.JSON(http.StatusInternalServerError, ErrorResponse{Error: err.Error()})
+		return
+	}
+
+	c.Status(http.StatusNoContent)
+}
+
+// GetCPFSecretarias godoc
+// @Summary Consultar secretarias de um CPF
+// @Description Retorna a lista de cd_uas vinculados ao CPF na base de apoio. Usado por outras APIs (app-go-api) via service account.
+// @Tags cpf-secretaria
+// @Produce json
+// @Param cpf path string true "CPF do usuário (11 dígitos)"
+// @Security BearerAuth
+// @Success 200 {object} models.CPFSecretariaQueryResponse
+// @Failure 400 {object} ErrorResponse
+// @Failure 401 {object} ErrorResponse
+// @Failure 500 {object} ErrorResponse
+// @Router /cpf-secretaria/{cpf} [get]
+func GetCPFSecretarias(c *gin.Context) {
+	cpf := c.Param("cpf")
+	if err := validateCPFParam(cpf); err != nil {
+		c.JSON(http.StatusBadRequest, ErrorResponse{Error: err.Error()})
+		return
+	}
+
+	if services.CPFSecretariaServiceInstance == nil {
+		c.JSON(http.StatusInternalServerError, ErrorResponse{Error: "service unavailable"})
+		return
+	}
+
+	cdUAs, err := services.CPFSecretariaServiceInstance.GetCdUAsByCPF(c.Request.Context(), cpf)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, ErrorResponse{Error: err.Error()})
+		return
+	}
+
+	if cdUAs == nil {
+		cdUAs = []string{}
+	}
+
+	c.JSON(http.StatusOK, models.CPFSecretariaQueryResponse{
+		CPF:   cpf,
+		CdUAs: cdUAs,
+	})
+}
+
+func validateCPFParam(cpf string) error {
+	cpf = strings.ReplaceAll(cpf, ".", "")
+	cpf = strings.ReplaceAll(cpf, "-", "")
+	if len(cpf) != 11 {
+		return fmt.Errorf("invalid CPF: must have 11 digits")
+	}
+	return nil
+}

--- a/internal/handlers/cpf_secretaria_handlers_test.go
+++ b/internal/handlers/cpf_secretaria_handlers_test.go
@@ -1,0 +1,250 @@
+package handlers
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/prefeitura-rio/app-rmi/internal/config"
+	"github.com/prefeitura-rio/app-rmi/internal/logging"
+	"github.com/prefeitura-rio/app-rmi/internal/models"
+	"github.com/prefeitura-rio/app-rmi/internal/services"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const testCPF = "12345678901"
+const testCdUA = "TEST-UA-001"
+
+func setupCPFSecretariaRouter(t *testing.T) (*gin.Engine, func()) {
+	t.Helper()
+	setupTestEnvironment()
+	require.NotNil(t, services.CPFSecretariaServiceInstance, "CPFSecretariaServiceInstance must be initialized")
+
+	_ = logging.InitLogger()
+	gin.SetMode(gin.TestMode)
+
+	if config.AppConfig == nil {
+		config.AppConfig = &config.Config{}
+	}
+	config.AppConfig.AdminGroup = "go:admin"
+
+	adminMiddleware := func(c *gin.Context) {
+		claims := &models.JWTClaims{PreferredUsername: "99999999999"}
+		claims.ResourceAccess.Superapp.Roles = []string{"go:admin"}
+		c.Set("claims", claims)
+		c.Next()
+	}
+
+	r := gin.New()
+	r.Use(adminMiddleware)
+	r.GET("/admin/cpf-secretaria/:cpf", AdminListCPFSecretaria)
+	r.POST("/admin/cpf-secretaria/:cpf", AdminAddCPFSecretaria)
+	r.DELETE("/admin/cpf-secretaria/:cpf/:cd_ua", AdminRemoveCPFSecretaria)
+	r.GET("/cpf-secretaria/:cpf", GetCPFSecretarias)
+
+	cleanup := func() {
+		ctx := context.Background()
+		coll := config.MongoDB.Collection(config.AppConfig.CPFSecretariaCollection)
+		_, _ = coll.DeleteMany(ctx, map[string]interface{}{"cpf": testCPF})
+	}
+	cleanup()
+
+	return r, cleanup
+}
+
+func TestAdminListCPFSecretaria_InvalidCPF(t *testing.T) {
+	r, cleanup := setupCPFSecretariaRouter(t)
+	defer cleanup()
+
+	req, _ := http.NewRequest(http.MethodGet, "/admin/cpf-secretaria/123", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+}
+
+func TestAdminListCPFSecretaria_EmptyList(t *testing.T) {
+	r, cleanup := setupCPFSecretariaRouter(t)
+	defer cleanup()
+
+	req, _ := http.NewRequest(http.MethodGet, "/admin/cpf-secretaria/"+testCPF, nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	var resp models.CPFSecretariaListResponse
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	assert.Equal(t, testCPF, resp.CPF)
+	assert.Empty(t, resp.Mappings)
+}
+
+func TestAdminAddCPFSecretaria_InvalidCPF(t *testing.T) {
+	r, cleanup := setupCPFSecretariaRouter(t)
+	defer cleanup()
+
+	body, _ := json.Marshal(map[string]string{"cd_ua": testCdUA})
+	req, _ := http.NewRequest(http.MethodPost, "/admin/cpf-secretaria/123", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+}
+
+func TestAdminAddCPFSecretaria_MissingCdUA(t *testing.T) {
+	r, cleanup := setupCPFSecretariaRouter(t)
+	defer cleanup()
+
+	body, _ := json.Marshal(map[string]string{"cd_ua": "   "})
+	req, _ := http.NewRequest(http.MethodPost, "/admin/cpf-secretaria/"+testCPF, bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+}
+
+func TestAdminAddCPFSecretaria_Success(t *testing.T) {
+	r, cleanup := setupCPFSecretariaRouter(t)
+	defer cleanup()
+
+	body, _ := json.Marshal(map[string]string{"cd_ua": testCdUA})
+	req, _ := http.NewRequest(http.MethodPost, "/admin/cpf-secretaria/"+testCPF, bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusCreated, w.Code)
+	var resp models.CPFSecretariaResponse
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	assert.Equal(t, testCPF, resp.CPF)
+	assert.Equal(t, testCdUA, resp.CdUA)
+}
+
+func TestAdminAddCPFSecretaria_Duplicate(t *testing.T) {
+	r, cleanup := setupCPFSecretariaRouter(t)
+	defer cleanup()
+
+	body, _ := json.Marshal(map[string]string{"cd_ua": testCdUA})
+	doPost := func() *httptest.ResponseRecorder {
+		req, _ := http.NewRequest(http.MethodPost, "/admin/cpf-secretaria/"+testCPF, bytes.NewReader(body))
+		req.Header.Set("Content-Type", "application/json")
+		w := httptest.NewRecorder()
+		r.ServeHTTP(w, req)
+		return w
+	}
+	require.Equal(t, http.StatusCreated, doPost().Code)
+
+	body, _ = json.Marshal(map[string]string{"cd_ua": testCdUA})
+	w := doPost()
+	assert.Equal(t, http.StatusConflict, w.Code)
+}
+
+func TestAdminRemoveCPFSecretaria_InvalidCPF(t *testing.T) {
+	r, cleanup := setupCPFSecretariaRouter(t)
+	defer cleanup()
+
+	req, _ := http.NewRequest(http.MethodDelete, "/admin/cpf-secretaria/123/"+testCdUA, nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+}
+
+func TestAdminRemoveCPFSecretaria_NotFound(t *testing.T) {
+	r, cleanup := setupCPFSecretariaRouter(t)
+	defer cleanup()
+
+	req, _ := http.NewRequest(http.MethodDelete, "/admin/cpf-secretaria/"+testCPF+"/NONEXISTENT", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusNotFound, w.Code)
+}
+
+func TestCPFSecretaria_FullCycle(t *testing.T) {
+	r, cleanup := setupCPFSecretariaRouter(t)
+	defer cleanup()
+
+	addBody, _ := json.Marshal(map[string]string{"cd_ua": testCdUA})
+	addReq, _ := http.NewRequest(http.MethodPost, "/admin/cpf-secretaria/"+testCPF, bytes.NewReader(addBody))
+	addReq.Header.Set("Content-Type", "application/json")
+	addW := httptest.NewRecorder()
+	r.ServeHTTP(addW, addReq)
+	require.Equal(t, http.StatusCreated, addW.Code)
+
+	listReq, _ := http.NewRequest(http.MethodGet, "/admin/cpf-secretaria/"+testCPF, nil)
+	listW := httptest.NewRecorder()
+	r.ServeHTTP(listW, listReq)
+	require.Equal(t, http.StatusOK, listW.Code)
+	var listResp models.CPFSecretariaListResponse
+	require.NoError(t, json.Unmarshal(listW.Body.Bytes(), &listResp))
+	assert.Len(t, listResp.Mappings, 1)
+	assert.Equal(t, testCdUA, listResp.Mappings[0].CdUA)
+
+	delReq, _ := http.NewRequest(http.MethodDelete, "/admin/cpf-secretaria/"+testCPF+"/"+testCdUA, nil)
+	delW := httptest.NewRecorder()
+	r.ServeHTTP(delW, delReq)
+	assert.Equal(t, http.StatusNoContent, delW.Code)
+
+	listReq2, _ := http.NewRequest(http.MethodGet, "/admin/cpf-secretaria/"+testCPF, nil)
+	listW2 := httptest.NewRecorder()
+	r.ServeHTTP(listW2, listReq2)
+	require.Equal(t, http.StatusOK, listW2.Code)
+	var listResp2 models.CPFSecretariaListResponse
+	require.NoError(t, json.Unmarshal(listW2.Body.Bytes(), &listResp2))
+	assert.Empty(t, listResp2.Mappings)
+}
+
+func TestGetCPFSecretarias_InvalidCPF(t *testing.T) {
+	r, cleanup := setupCPFSecretariaRouter(t)
+	defer cleanup()
+
+	req, _ := http.NewRequest(http.MethodGet, "/cpf-secretaria/123", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+}
+
+func TestGetCPFSecretarias_EmptyResult(t *testing.T) {
+	r, cleanup := setupCPFSecretariaRouter(t)
+	defer cleanup()
+
+	req, _ := http.NewRequest(http.MethodGet, "/cpf-secretaria/"+testCPF, nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	var resp models.CPFSecretariaQueryResponse
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	assert.Equal(t, testCPF, resp.CPF)
+	assert.Empty(t, resp.CdUAs)
+}
+
+func TestGetCPFSecretarias_WithMappings(t *testing.T) {
+	r, cleanup := setupCPFSecretariaRouter(t)
+	defer cleanup()
+
+	addBody, _ := json.Marshal(map[string]string{"cd_ua": testCdUA})
+	addReq, _ := http.NewRequest(http.MethodPost, "/admin/cpf-secretaria/"+testCPF, bytes.NewReader(addBody))
+	addReq.Header.Set("Content-Type", "application/json")
+	addW := httptest.NewRecorder()
+	r.ServeHTTP(addW, addReq)
+	require.Equal(t, http.StatusCreated, addW.Code)
+
+	req, _ := http.NewRequest(http.MethodGet, "/cpf-secretaria/"+testCPF, nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	var resp models.CPFSecretariaQueryResponse
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	assert.Equal(t, testCPF, resp.CPF)
+	assert.Contains(t, resp.CdUAs, testCdUA)
+}

--- a/internal/handlers/cpf_secretaria_handlers_test.go
+++ b/internal/handlers/cpf_secretaria_handlers_test.go
@@ -96,6 +96,18 @@ func TestAdminAddCPFSecretaria_InvalidCPF(t *testing.T) {
 	assert.Equal(t, http.StatusBadRequest, w.Code)
 }
 
+func TestAdminAddCPFSecretaria_InvalidJSON(t *testing.T) {
+	r, cleanup := setupCPFSecretariaRouter(t)
+	defer cleanup()
+
+	req, _ := http.NewRequest(http.MethodPost, "/admin/cpf-secretaria/"+testCPF, bytes.NewReader([]byte(`{not valid json`)))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+}
+
 func TestAdminAddCPFSecretaria_MissingCdUA(t *testing.T) {
 	r, cleanup := setupCPFSecretariaRouter(t)
 	defer cleanup()

--- a/internal/models/cpf_secretaria.go
+++ b/internal/models/cpf_secretaria.go
@@ -1,0 +1,50 @@
+package models
+
+import (
+	"time"
+
+	"go.mongodb.org/mongo-driver/bson/primitive"
+)
+
+type CPFSecretariaMapping struct {
+	ID        primitive.ObjectID `bson:"_id,omitempty" json:"id"`
+	CPF       string             `bson:"cpf"           json:"cpf"`
+	CdUA      string             `bson:"cd_ua"         json:"cd_ua"`
+	CreatedAt time.Time          `bson:"created_at"    json:"created_at"`
+	UpdatedAt time.Time          `bson:"updated_at"    json:"updated_at"`
+	CreatedBy string             `bson:"created_by"    json:"created_by"`
+}
+
+type CPFSecretariaResponse struct {
+	ID        string    `json:"id"`
+	CPF       string    `json:"cpf"`
+	CdUA      string    `json:"cd_ua"`
+	CreatedAt time.Time `json:"created_at"`
+	UpdatedAt time.Time `json:"updated_at"`
+	CreatedBy string    `json:"created_by"`
+}
+
+func (m *CPFSecretariaMapping) ToResponse() CPFSecretariaResponse {
+	return CPFSecretariaResponse{
+		ID:        m.ID.Hex(),
+		CPF:       m.CPF,
+		CdUA:      m.CdUA,
+		CreatedAt: m.CreatedAt,
+		UpdatedAt: m.UpdatedAt,
+		CreatedBy: m.CreatedBy,
+	}
+}
+
+type AddCPFSecretariaRequest struct {
+	CdUA string `json:"cd_ua" binding:"required"`
+}
+
+type CPFSecretariaListResponse struct {
+	CPF      string                  `json:"cpf"`
+	Mappings []CPFSecretariaResponse `json:"mappings"`
+}
+
+type CPFSecretariaQueryResponse struct {
+	CPF   string   `json:"cpf"`
+	CdUAs []string `json:"cd_uas"`
+}

--- a/internal/services/common_test.go
+++ b/internal/services/common_test.go
@@ -51,6 +51,7 @@ func setupTestEnvironment() {
 			"MONGODB_PETS_SELF_REGISTERED_COLLECTION":  "pets_self_registered",
 			"MONGODB_NOTIFICATION_CATEGORY_COLLECTION": "notification_categories",
 			"MONGODB_USER_CONFIG_COLLECTION":           "user_config",
+			"MONGODB_CPF_SECRETARIA_COLLECTION":        "cpf_secretaria_svc_test",
 		}
 		for key, defaultValue := range collections {
 			if os.Getenv(key) == "" {

--- a/internal/services/cpf_secretaria_service.go
+++ b/internal/services/cpf_secretaria_service.go
@@ -1,0 +1,112 @@
+package services
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/prefeitura-rio/app-rmi/internal/config"
+	"github.com/prefeitura-rio/app-rmi/internal/models"
+	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/bson/primitive"
+	"go.mongodb.org/mongo-driver/mongo"
+	"go.mongodb.org/mongo-driver/mongo/options"
+	"go.uber.org/zap"
+)
+
+type CPFSecretariaService struct {
+	database *mongo.Database
+}
+
+func NewCPFSecretariaService(database *mongo.Database) *CPFSecretariaService {
+	return &CPFSecretariaService{database: database}
+}
+
+var CPFSecretariaServiceInstance *CPFSecretariaService
+
+func InitCPFSecretariaService() {
+	CPFSecretariaServiceInstance = NewCPFSecretariaService(config.MongoDB)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	coll := config.MongoDB.Collection(config.AppConfig.CPFSecretariaCollection)
+	indexes := []mongo.IndexModel{
+		{Keys: bson.D{{Key: "cpf", Value: 1}}},
+		{
+			Keys:    bson.D{{Key: "cpf", Value: 1}, {Key: "cd_ua", Value: 1}},
+			Options: options.Index().SetUnique(true),
+		},
+	}
+	if _, err := coll.Indexes().CreateMany(ctx, indexes); err != nil {
+		zap.L().Warn("cpf_secretaria: failed to create indexes", zap.Error(err))
+	}
+}
+
+func normalizeCPF(cpf string) string {
+	cpf = strings.ReplaceAll(cpf, ".", "")
+	cpf = strings.ReplaceAll(cpf, "-", "")
+	return strings.TrimSpace(cpf)
+}
+
+func (s *CPFSecretariaService) ListByCPF(ctx context.Context, cpf string) ([]models.CPFSecretariaMapping, error) {
+	coll := s.database.Collection(config.AppConfig.CPFSecretariaCollection)
+	cursor, err := coll.Find(ctx, bson.M{"cpf": normalizeCPF(cpf)})
+	if err != nil {
+		return nil, fmt.Errorf("cpf_secretaria: list: %w", err)
+	}
+	defer cursor.Close(ctx)
+
+	var mappings []models.CPFSecretariaMapping
+	if err := cursor.All(ctx, &mappings); err != nil {
+		return nil, fmt.Errorf("cpf_secretaria: decode: %w", err)
+	}
+	return mappings, nil
+}
+
+func (s *CPFSecretariaService) AddMapping(ctx context.Context, cpf, cdUA, createdBy string) (*models.CPFSecretariaMapping, error) {
+	coll := s.database.Collection(config.AppConfig.CPFSecretariaCollection)
+	now := time.Now()
+	mapping := models.CPFSecretariaMapping{
+		ID:        primitive.NewObjectID(),
+		CPF:       normalizeCPF(cpf),
+		CdUA:      cdUA,
+		CreatedAt: now,
+		UpdatedAt: now,
+		CreatedBy: createdBy,
+	}
+
+	_, err := coll.InsertOne(ctx, mapping)
+	if err != nil {
+		if mongo.IsDuplicateKeyError(err) {
+			return nil, fmt.Errorf("cpf_secretaria: mapping already exists for CPF %s and cd_ua %s", cpf, cdUA)
+		}
+		return nil, fmt.Errorf("cpf_secretaria: insert: %w", err)
+	}
+	return &mapping, nil
+}
+
+func (s *CPFSecretariaService) RemoveMapping(ctx context.Context, cpf, cdUA string) error {
+	coll := s.database.Collection(config.AppConfig.CPFSecretariaCollection)
+	result, err := coll.DeleteOne(ctx, bson.M{"cpf": normalizeCPF(cpf), "cd_ua": cdUA})
+	if err != nil {
+		return fmt.Errorf("cpf_secretaria: delete: %w", err)
+	}
+	if result.DeletedCount == 0 {
+		return fmt.Errorf("cpf_secretaria: mapping not found for CPF %s and cd_ua %s", cpf, cdUA)
+	}
+	return nil
+}
+
+func (s *CPFSecretariaService) GetCdUAsByCPF(ctx context.Context, cpf string) ([]string, error) {
+	mappings, err := s.ListByCPF(ctx, cpf)
+	if err != nil {
+		return nil, err
+	}
+	cdUAs := make([]string, 0, len(mappings))
+	for _, m := range mappings {
+		cdUAs = append(cdUAs, m.CdUA)
+	}
+	return cdUAs, nil
+}

--- a/internal/services/cpf_secretaria_service.go
+++ b/internal/services/cpf_secretaria_service.go
@@ -2,6 +2,7 @@ package services
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strings"
 	"time"
@@ -67,17 +68,28 @@ func (s *CPFSecretariaService) ListByCPF(ctx context.Context, cpf string) ([]mod
 
 func (s *CPFSecretariaService) AddMapping(ctx context.Context, cpf, cdUA, createdBy string) (*models.CPFSecretariaMapping, error) {
 	coll := s.database.Collection(config.AppConfig.CPFSecretariaCollection)
+	normalizedCPF := normalizeCPF(cpf)
+
+	var existing models.CPFSecretariaMapping
+	err := coll.FindOne(ctx, bson.M{"cpf": normalizedCPF, "cd_ua": cdUA}).Decode(&existing)
+	if err == nil {
+		return nil, fmt.Errorf("cpf_secretaria: mapping already exists for CPF %s and cd_ua %s", cpf, cdUA)
+	}
+	if !errors.Is(err, mongo.ErrNoDocuments) {
+		return nil, fmt.Errorf("cpf_secretaria: check existing: %w", err)
+	}
+
 	now := time.Now()
 	mapping := models.CPFSecretariaMapping{
 		ID:        primitive.NewObjectID(),
-		CPF:       normalizeCPF(cpf),
+		CPF:       normalizedCPF,
 		CdUA:      cdUA,
 		CreatedAt: now,
 		UpdatedAt: now,
 		CreatedBy: createdBy,
 	}
 
-	_, err := coll.InsertOne(ctx, mapping)
+	_, err = coll.InsertOne(ctx, mapping)
 	if err != nil {
 		if mongo.IsDuplicateKeyError(err) {
 			return nil, fmt.Errorf("cpf_secretaria: mapping already exists for CPF %s and cd_ua %s", cpf, cdUA)

--- a/internal/services/cpf_secretaria_service_test.go
+++ b/internal/services/cpf_secretaria_service_test.go
@@ -1,0 +1,143 @@
+package services
+
+import (
+	"context"
+	"testing"
+
+	"github.com/prefeitura-rio/app-rmi/internal/config"
+	"github.com/prefeitura-rio/app-rmi/internal/logging"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const svcTestCPF = "98765432100"
+const svcTestCdUA = "SVC-UA-001"
+
+func setupCPFSecretariaServiceTest(t *testing.T) (*CPFSecretariaService, func()) {
+	t.Helper()
+	setupTestEnvironment()
+
+	if config.MongoDB == nil {
+		t.Skip("Skipping CPFSecretaria service tests: MongoDB not initialized")
+	}
+
+	_ = logging.InitLogger()
+
+	if config.AppConfig == nil {
+		config.AppConfig = &config.Config{}
+	}
+
+	InitCPFSecretariaService()
+	require.NotNil(t, CPFSecretariaServiceInstance)
+
+	svc := CPFSecretariaServiceInstance
+
+	cleanup := func() {
+		ctx := context.Background()
+		coll := config.MongoDB.Collection(config.AppConfig.CPFSecretariaCollection)
+		_, _ = coll.DeleteMany(ctx, map[string]interface{}{"cpf": svcTestCPF})
+	}
+	cleanup()
+
+	return svc, cleanup
+}
+
+func TestCPFSecretariaService_ListByCPF_Empty(t *testing.T) {
+	svc, cleanup := setupCPFSecretariaServiceTest(t)
+	defer cleanup()
+
+	mappings, err := svc.ListByCPF(context.Background(), svcTestCPF)
+	require.NoError(t, err)
+	assert.Empty(t, mappings)
+}
+
+func TestCPFSecretariaService_AddMapping_Success(t *testing.T) {
+	svc, cleanup := setupCPFSecretariaServiceTest(t)
+	defer cleanup()
+
+	mapping, err := svc.AddMapping(context.Background(), svcTestCPF, svcTestCdUA, "test-admin")
+	require.NoError(t, err)
+	assert.Equal(t, svcTestCPF, mapping.CPF)
+	assert.Equal(t, svcTestCdUA, mapping.CdUA)
+	assert.Equal(t, "test-admin", mapping.CreatedBy)
+	assert.NotEmpty(t, mapping.ID)
+}
+
+func TestCPFSecretariaService_AddMapping_Duplicate(t *testing.T) {
+	svc, cleanup := setupCPFSecretariaServiceTest(t)
+	defer cleanup()
+
+	_, err := svc.AddMapping(context.Background(), svcTestCPF, svcTestCdUA, "admin")
+	require.NoError(t, err)
+
+	_, err = svc.AddMapping(context.Background(), svcTestCPF, svcTestCdUA, "admin")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "already exists")
+}
+
+func TestCPFSecretariaService_RemoveMapping_Success(t *testing.T) {
+	svc, cleanup := setupCPFSecretariaServiceTest(t)
+	defer cleanup()
+
+	_, err := svc.AddMapping(context.Background(), svcTestCPF, svcTestCdUA, "admin")
+	require.NoError(t, err)
+
+	err = svc.RemoveMapping(context.Background(), svcTestCPF, svcTestCdUA)
+	require.NoError(t, err)
+
+	mappings, err := svc.ListByCPF(context.Background(), svcTestCPF)
+	require.NoError(t, err)
+	assert.Empty(t, mappings)
+}
+
+func TestCPFSecretariaService_RemoveMapping_NotFound(t *testing.T) {
+	svc, cleanup := setupCPFSecretariaServiceTest(t)
+	defer cleanup()
+
+	err := svc.RemoveMapping(context.Background(), svcTestCPF, "NONEXISTENT")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not found")
+}
+
+func TestCPFSecretariaService_GetCdUAsByCPF(t *testing.T) {
+	svc, cleanup := setupCPFSecretariaServiceTest(t)
+	defer cleanup()
+
+	_, err := svc.AddMapping(context.Background(), svcTestCPF, svcTestCdUA, "admin")
+	require.NoError(t, err)
+	_, err = svc.AddMapping(context.Background(), svcTestCPF, "SVC-UA-002", "admin")
+	require.NoError(t, err)
+
+	cdUAs, err := svc.GetCdUAsByCPF(context.Background(), svcTestCPF)
+	require.NoError(t, err)
+	assert.Len(t, cdUAs, 2)
+	assert.Contains(t, cdUAs, svcTestCdUA)
+	assert.Contains(t, cdUAs, "SVC-UA-002")
+}
+
+func TestCPFSecretariaService_ToResponse(t *testing.T) {
+	svc, cleanup := setupCPFSecretariaServiceTest(t)
+	defer cleanup()
+
+	mapping, err := svc.AddMapping(context.Background(), svcTestCPF, svcTestCdUA, "admin")
+	require.NoError(t, err)
+
+	resp := mapping.ToResponse()
+	assert.Equal(t, svcTestCPF, resp.CPF)
+	assert.Equal(t, svcTestCdUA, resp.CdUA)
+	assert.NotEmpty(t, resp.ID)
+}
+
+func TestNormalizeCPFVariants(t *testing.T) {
+	svc, cleanup := setupCPFSecretariaServiceTest(t)
+	defer cleanup()
+
+	formattedCPF := "987.654.321-00"
+	_, err := svc.AddMapping(context.Background(), formattedCPF, svcTestCdUA, "admin")
+	require.NoError(t, err)
+
+	mappings, err := svc.ListByCPF(context.Background(), svcTestCPF)
+	require.NoError(t, err)
+	assert.Len(t, mappings, 1)
+	assert.Equal(t, svcTestCPF, mappings[0].CPF)
+}


### PR DESCRIPTION
## Summary

- Adds CPF ↔ secretaria mapping storage in MongoDB (`cpf_secretaria_mappings` collection) with compound unique index on `{cpf, cd_ua}`
- Admin CRUD: `GET/POST/DELETE /v1/admin/cpf-secretaria/:cpf` (requires `admin` role)
- Authenticated query: `GET /v1/cpf-secretaria/:cpf` (service-account callable, used by `app-go-api` to resolve secretaria for an editor)
- Returns list of `cd_ua` codes — the same identifier stored as `orgao_id` on Curso/Emprego

## Motivation

Editors in `app-go-api` need to be restricted to see only cursos/empregos from their secretaria(s). This endpoint is the source of truth for that mapping, replacing the implicit Heimdall group fallback.

## Phase scope

Phase 1: base de apoio CRUD + query endpoint.
Phase 2 (future): Ergon sync to auto-populate mappings.

## Testing

- `go build ./...` passes
- Unit tests for handlers and service to be added in follow-up (TDD backfill)