### PR TITLE
fix: allow trusted service accounts to bypass CNPJ ownership check

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -114,7 +114,8 @@ type Config struct {
 	DBBatchSize   int `json:"db_batch_size"`
 
 	// Authorization configuration
-	AdminGroup string `json:"admin_group"`
+	AdminGroup            string   `json:"admin_group"`
+	TrustedServiceClients []string `json:"trusted_service_clients"`
 
 	// Index maintenance configuration
 	IndexMaintenanceInterval time.Duration `json:"index_maintenance_interval"`
@@ -423,7 +424,8 @@ func LoadConfig() error {
 		DBBatchSize:   getEnvAsIntOrDefault("DB_BATCH_SIZE", 100),
 
 		// Authorization configuration
-		AdminGroup: getEnvOrDefault("ADMIN_GROUP", "rmi-admin"),
+		AdminGroup:            getEnvOrDefault("ADMIN_GROUP", "rmi-admin"),
+		TrustedServiceClients: parseCommaSeparatedList(getEnvOrDefault("TRUSTED_SERVICE_CLIENTS", "")),
 
 		// Index maintenance configuration
 		IndexMaintenanceInterval: indexMaintenanceInterval,

--- a/internal/handlers/legal_entity.go
+++ b/internal/handlers/legal_entity.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/gin-gonic/gin"
+	"github.com/prefeitura-rio/app-rmi/internal/config"
 	"github.com/prefeitura-rio/app-rmi/internal/models"
 	"github.com/prefeitura-rio/app-rmi/internal/observability"
 	"github.com/prefeitura-rio/app-rmi/internal/services"
@@ -223,6 +224,26 @@ func GetLegalEntityByCNPJ(c *gin.Context) {
 		accessSpan.End()
 		c.JSON(http.StatusUnauthorized, ErrorResponse{Error: "Unauthorized"})
 		return
+	}
+
+	for _, clientID := range config.AppConfig.TrustedServiceClients {
+		if jwtClaims.AZP == clientID {
+			utils.AddSpanAttribute(accessSpan, "access_granted", "trusted_service")
+			utils.AddSpanAttribute(accessSpan, "trusted_azp", jwtClaims.AZP)
+			accessSpan.End()
+			observability.DatabaseOperations.WithLabelValues("find", "success").Inc()
+
+			_, responseSpan := utils.TraceResponseSerialization(ctx, "success")
+			c.JSON(http.StatusOK, entity)
+			responseSpan.End()
+
+			logger.Debug("GetLegalEntityByCNPJ completed (trusted service access)",
+				zap.String("cnpj", cnpj),
+				zap.String("azp", jwtClaims.AZP),
+				zap.Duration("total_duration", time.Since(startTime)),
+				zap.String("status", "success"))
+			return
+		}
 	}
 
 	// Check if user is admin

--- a/internal/handlers/legal_entity_handlers_test.go
+++ b/internal/handlers/legal_entity_handlers_test.go
@@ -67,6 +67,17 @@ func userMiddleware(cpf string) gin.HandlerFunc {
 	}
 }
 
+func serviceAccountMiddleware(clientID string) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		claims := &models.JWTClaims{
+			AZP:               clientID,
+			PreferredUsername: "service-account-" + clientID,
+		}
+		c.Set("claims", claims)
+		c.Next()
+	}
+}
+
 // Helper function to create test legal entity
 //
 //nolint:unused // Keeping for potential future use
@@ -894,6 +905,103 @@ func TestGetLegalEntityByCNPJ_MultiplePartners_OnlyOneMatch(t *testing.T) {
 	require.NoError(t, err)
 
 	assert.Equal(t, "11222333000181", response.CNPJ)
+}
+
+func TestGetLegalEntityByCNPJ_TrustedServiceAccess(t *testing.T) {
+	_, cleanup := setupLegalEntityHandlersTest(t)
+	defer cleanup()
+
+	ctx := context.Background()
+	collection := config.MongoDB.Collection(config.AppConfig.LegalEntityCollection)
+
+	entity := bson.M{
+		"cnpj":         "11222333000181",
+		"razao_social": "Test Company Service",
+		"responsavel": bson.M{
+			"cpf": "99999999999",
+		},
+	}
+	_, err := collection.InsertOne(ctx, entity)
+	require.NoError(t, err)
+
+	config.AppConfig.TrustedServiceClients = []string{"app-go-api"}
+	defer func() { config.AppConfig.TrustedServiceClients = nil }()
+
+	router := gin.New()
+	router.Use(serviceAccountMiddleware("app-go-api"))
+	router.GET("/legal-entity/:cnpj", GetLegalEntityByCNPJ)
+
+	req, _ := http.NewRequest("GET", "/legal-entity/11222333000181", nil)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var response models.LegalEntity
+	err = json.Unmarshal(w.Body.Bytes(), &response)
+	require.NoError(t, err)
+	assert.Equal(t, "11222333000181", response.CNPJ)
+}
+
+func TestGetLegalEntityByCNPJ_UntrustedServiceDenied(t *testing.T) {
+	_, cleanup := setupLegalEntityHandlersTest(t)
+	defer cleanup()
+
+	ctx := context.Background()
+	collection := config.MongoDB.Collection(config.AppConfig.LegalEntityCollection)
+
+	entity := bson.M{
+		"cnpj":         "11222333000181",
+		"razao_social": "Test Company Service",
+		"responsavel": bson.M{
+			"cpf": "99999999999",
+		},
+	}
+	_, err := collection.InsertOne(ctx, entity)
+	require.NoError(t, err)
+
+	config.AppConfig.TrustedServiceClients = []string{"app-go-api"}
+	defer func() { config.AppConfig.TrustedServiceClients = nil }()
+
+	router := gin.New()
+	router.Use(serviceAccountMiddleware("unknown-service"))
+	router.GET("/legal-entity/:cnpj", GetLegalEntityByCNPJ)
+
+	req, _ := http.NewRequest("GET", "/legal-entity/11222333000181", nil)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusForbidden, w.Code)
+}
+
+func TestGetLegalEntityByCNPJ_EmptyTrustedServiceList(t *testing.T) {
+	_, cleanup := setupLegalEntityHandlersTest(t)
+	defer cleanup()
+
+	ctx := context.Background()
+	collection := config.MongoDB.Collection(config.AppConfig.LegalEntityCollection)
+
+	entity := bson.M{
+		"cnpj":         "11222333000181",
+		"razao_social": "Test Company Service",
+		"responsavel": bson.M{
+			"cpf": "99999999999",
+		},
+	}
+	_, err := collection.InsertOne(ctx, entity)
+	require.NoError(t, err)
+
+	config.AppConfig.TrustedServiceClients = nil
+
+	router := gin.New()
+	router.Use(serviceAccountMiddleware("app-go-api"))
+	router.GET("/legal-entity/:cnpj", GetLegalEntityByCNPJ)
+
+	req, _ := http.NewRequest("GET", "/legal-entity/11222333000181", nil)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusForbidden, w.Code)
 }
 
 // Helper functions


### PR DESCRIPTION
## Problema

O endpoint \`GET /v1/legal-entity/{cnpj}\` retornava 403 para chamadas vindas do \`app-go-api\`.

O \`app-go-api\` usa um **service account token** (client credentials) para chamar esse endpoint. O handler aplicava checks de \`responsible_person.cpf\` e \`socios[].cpf_socio\` sobre esse token — mas o \`preferred_username\` de um service account não é um CPF, então todos os checks falhavam e o endpoint retornava 403 para qualquer CNPJ.

## Solução

Adiciona suporte a uma lista de service accounts confiáveis via env var \`TRUSTED_SERVICE_CLIENTS\` (valores de \`azp\` separados por vírgula).

Quando o claim \`azp\` do JWT está nessa lista, o handler retorna a entidade diretamente antes dos checks de ownership — modelando a confiança máquina-a-máquina sem exigir role \`go:admin\` no Keycloak.

**Deploy necessário:** adicionar \`TRUSTED_SERVICE_CLIENTS=<client_id_do_app-go-api>\` ao secret do app-rmi em produção.

## Mudanças

- `internal/config/config.go` — novo campo `TrustedServiceClients []string`, lido de `TRUSTED_SERVICE_CLIENTS`
- `internal/handlers/legal_entity.go` — check de `azp` antes dos checks de ownership em `GetLegalEntityByCNPJ`
- `internal/handlers/legal_entity_handlers_test.go` — 3 novos testes: trusted service acessa, service desconhecido nega, lista vazia nega