### PR TITLE
chore: raise minReplicaCount for 600k event

### DIFF
--- a/k8s/prod/resources.yaml
+++ b/k8s/prod/resources.yaml
@@ -162,7 +162,7 @@ spec:
     apiVersion: argoproj.io/v1alpha1
     kind: Rollout
     name: rmi
-  minReplicaCount: 1
+  minReplicaCount: 3
   maxReplicaCount: 10
   cooldownPeriod: 30
   pollingInterval: 10

--- a/k8s/staging/resources.yaml
+++ b/k8s/staging/resources.yaml
@@ -138,7 +138,7 @@ spec:
     apiVersion: argoproj.io/v1alpha1
     kind: Rollout
     name: rmi
-  minReplicaCount: 1
+  minReplicaCount: 3
   maxReplicaCount: 10
   cooldownPeriod: 30
   pollingInterval: 10


### PR DESCRIPTION
Raises `minReplicaCount` from 1 to 3 in both `k8s/prod` and `k8s/staging` ScaledObjects to ensure a warm floor of pods before the 600k user event.