### PR TITLE
fix: usa github.ref_name no checkout do release workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -16,7 +16,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
         with:
-          ref: main
+          ref: ${{ github.ref_name }}
           fetch-depth: 0
 
       - name: Set up Go


### PR DESCRIPTION
Substitui `ref: main` por `ref: ${{ github.ref_name }}` no step de checkout do release workflow.

Com `ref: main` hardcoded, um rerun de release antiga buildava o HEAD atual da main em vez do commit que a tag apontava — exatamente o incidente que ocorreu na sexta.