### PR TITLE
docs: regenerate swagger with cpf-secretaria routes

### DIFF
--- a/docs/docs.go
+++ b/docs/docs.go
@@ -903,6 +903,203 @@ const docTemplate = `{
                 }
             }
         },
+        "/admin/cpf-secretaria/{cpf}": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Retorna todos os vínculos de secretaria associados a um CPF na base de apoio.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "admin",
+                    "cpf-secretaria"
+                ],
+                "summary": "Listar vínculos CPF-Secretaria",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "CPF do usuário (11 dígitos)",
+                        "name": "cpf",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/models.CPFSecretariaListResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/handlers.ErrorResponse"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "$ref": "#/definitions/handlers.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/handlers.ErrorResponse"
+                        }
+                    }
+                }
+            },
+            "post": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Vincula um CPF a uma secretaria (cd_ua SICI) na base de apoio. Um CPF pode ter múltiplos vínculos.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "admin",
+                    "cpf-secretaria"
+                ],
+                "summary": "Adicionar vínculo CPF-Secretaria",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "CPF do usuário (11 dígitos)",
+                        "name": "cpf",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "cd_ua da secretaria",
+                        "name": "data",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/models.AddCPFSecretariaRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "description": "Created",
+                        "schema": {
+                            "$ref": "#/definitions/models.CPFSecretariaResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/handlers.ErrorResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/handlers.ErrorResponse"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "$ref": "#/definitions/handlers.ErrorResponse"
+                        }
+                    },
+                    "409": {
+                        "description": "Conflict",
+                        "schema": {
+                            "$ref": "#/definitions/handlers.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/handlers.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/admin/cpf-secretaria/{cpf}/{cd_ua}": {
+            "delete": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Remove o vínculo entre um CPF e uma secretaria específica.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "admin",
+                    "cpf-secretaria"
+                ],
+                "summary": "Remover vínculo CPF-Secretaria",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "CPF do usuário (11 dígitos)",
+                        "name": "cpf",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Código da UA (SICI)",
+                        "name": "cd_ua",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "No Content"
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/handlers.ErrorResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/handlers.ErrorResponse"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "$ref": "#/definitions/handlers.ErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/handlers.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/handlers.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
         "/admin/notification-categories": {
             "post": {
                 "security": [
@@ -3821,6 +4018,58 @@ const docTemplate = `{
                 }
             }
         },
+        "/cpf-secretaria/{cpf}": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Retorna a lista de cd_uas vinculados ao CPF na base de apoio. Usado por outras APIs (app-go-api) via service account.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "cpf-secretaria"
+                ],
+                "summary": "Consultar secretarias de um CPF",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "CPF do usuário (11 dígitos)",
+                        "name": "cpf",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/models.CPFSecretariaQueryResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/handlers.ErrorResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/handlers.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/handlers.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
         "/departments": {
             "get": {
                 "description": "Recupera a lista paginada de departamentos com filtros opcionais (hierarquia, nível, busca).",
@@ -5867,6 +6116,17 @@ const docTemplate = `{
                 }
             }
         },
+        "models.AddCPFSecretariaRequest": {
+            "type": "object",
+            "required": [
+                "cd_ua"
+            ],
+            "properties": {
+                "cd_ua": {
+                    "type": "string"
+                }
+            }
+        },
         "models.Aluno": {
             "type": "object",
             "properties": {
@@ -6185,6 +6445,57 @@ const docTemplate = `{
                 },
                 "pagination": {
                     "$ref": "#/definitions/models.PaginationInfo"
+                }
+            }
+        },
+        "models.CPFSecretariaListResponse": {
+            "type": "object",
+            "properties": {
+                "cpf": {
+                    "type": "string"
+                },
+                "mappings": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/models.CPFSecretariaResponse"
+                    }
+                }
+            }
+        },
+        "models.CPFSecretariaQueryResponse": {
+            "type": "object",
+            "properties": {
+                "cd_uas": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "cpf": {
+                    "type": "string"
+                }
+            }
+        },
+        "models.CPFSecretariaResponse": {
+            "type": "object",
+            "properties": {
+                "cd_ua": {
+                    "type": "string"
+                },
+                "cpf": {
+                    "type": "string"
+                },
+                "created_at": {
+                    "type": "string"
+                },
+                "created_by": {
+                    "type": "string"
+                },
+                "id": {
+                    "type": "string"
+                },
+                "updated_at": {
+                    "type": "string"
                 }
             }
         },
@@ -7093,6 +7404,23 @@ const docTemplate = `{
                 }
             }
         },
+        "models.OtherTutor": {
+            "type": "object",
+            "properties": {
+                "cpf": {
+                    "type": "string"
+                },
+                "email": {
+                    "type": "string"
+                },
+                "nome": {
+                    "type": "string"
+                },
+                "telefone": {
+                    "type": "string"
+                }
+            }
+        },
         "models.PaginatedLegalEntities": {
             "type": "object",
             "properties": {
@@ -7267,6 +7595,12 @@ const docTemplate = `{
                 },
                 "nascimento_data": {
                     "type": "string"
+                },
+                "outros_tutores": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/models.OtherTutor"
+                    }
                 },
                 "pedigree_indicador": {
                     "type": "boolean"
@@ -7943,6 +8277,9 @@ const docTemplate = `{
         },
         "models.UserConfigOptInResponse": {
             "type": "object",
+            "required": [
+                "opt_in"
+            ],
             "properties": {
                 "category_opt_ins": {
                     "type": "object",

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -901,6 +901,203 @@
                 }
             }
         },
+        "/admin/cpf-secretaria/{cpf}": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Retorna todos os vínculos de secretaria associados a um CPF na base de apoio.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "admin",
+                    "cpf-secretaria"
+                ],
+                "summary": "Listar vínculos CPF-Secretaria",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "CPF do usuário (11 dígitos)",
+                        "name": "cpf",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/models.CPFSecretariaListResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/handlers.ErrorResponse"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "$ref": "#/definitions/handlers.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/handlers.ErrorResponse"
+                        }
+                    }
+                }
+            },
+            "post": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Vincula um CPF a uma secretaria (cd_ua SICI) na base de apoio. Um CPF pode ter múltiplos vínculos.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "admin",
+                    "cpf-secretaria"
+                ],
+                "summary": "Adicionar vínculo CPF-Secretaria",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "CPF do usuário (11 dígitos)",
+                        "name": "cpf",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "cd_ua da secretaria",
+                        "name": "data",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/models.AddCPFSecretariaRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "description": "Created",
+                        "schema": {
+                            "$ref": "#/definitions/models.CPFSecretariaResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/handlers.ErrorResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/handlers.ErrorResponse"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "$ref": "#/definitions/handlers.ErrorResponse"
+                        }
+                    },
+                    "409": {
+                        "description": "Conflict",
+                        "schema": {
+                            "$ref": "#/definitions/handlers.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/handlers.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/admin/cpf-secretaria/{cpf}/{cd_ua}": {
+            "delete": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Remove o vínculo entre um CPF e uma secretaria específica.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "admin",
+                    "cpf-secretaria"
+                ],
+                "summary": "Remover vínculo CPF-Secretaria",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "CPF do usuário (11 dígitos)",
+                        "name": "cpf",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Código da UA (SICI)",
+                        "name": "cd_ua",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "No Content"
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/handlers.ErrorResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/handlers.ErrorResponse"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "$ref": "#/definitions/handlers.ErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/handlers.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/handlers.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
         "/admin/notification-categories": {
             "post": {
                 "security": [
@@ -3819,6 +4016,58 @@
                 }
             }
         },
+        "/cpf-secretaria/{cpf}": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Retorna a lista de cd_uas vinculados ao CPF na base de apoio. Usado por outras APIs (app-go-api) via service account.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "cpf-secretaria"
+                ],
+                "summary": "Consultar secretarias de um CPF",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "CPF do usuário (11 dígitos)",
+                        "name": "cpf",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/models.CPFSecretariaQueryResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/handlers.ErrorResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/handlers.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/handlers.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
         "/departments": {
             "get": {
                 "description": "Recupera a lista paginada de departamentos com filtros opcionais (hierarquia, nível, busca).",
@@ -5865,6 +6114,17 @@
                 }
             }
         },
+        "models.AddCPFSecretariaRequest": {
+            "type": "object",
+            "required": [
+                "cd_ua"
+            ],
+            "properties": {
+                "cd_ua": {
+                    "type": "string"
+                }
+            }
+        },
         "models.Aluno": {
             "type": "object",
             "properties": {
@@ -6183,6 +6443,57 @@
                 },
                 "pagination": {
                     "$ref": "#/definitions/models.PaginationInfo"
+                }
+            }
+        },
+        "models.CPFSecretariaListResponse": {
+            "type": "object",
+            "properties": {
+                "cpf": {
+                    "type": "string"
+                },
+                "mappings": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/models.CPFSecretariaResponse"
+                    }
+                }
+            }
+        },
+        "models.CPFSecretariaQueryResponse": {
+            "type": "object",
+            "properties": {
+                "cd_uas": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "cpf": {
+                    "type": "string"
+                }
+            }
+        },
+        "models.CPFSecretariaResponse": {
+            "type": "object",
+            "properties": {
+                "cd_ua": {
+                    "type": "string"
+                },
+                "cpf": {
+                    "type": "string"
+                },
+                "created_at": {
+                    "type": "string"
+                },
+                "created_by": {
+                    "type": "string"
+                },
+                "id": {
+                    "type": "string"
+                },
+                "updated_at": {
+                    "type": "string"
                 }
             }
         },
@@ -7091,6 +7402,23 @@
                 }
             }
         },
+        "models.OtherTutor": {
+            "type": "object",
+            "properties": {
+                "cpf": {
+                    "type": "string"
+                },
+                "email": {
+                    "type": "string"
+                },
+                "nome": {
+                    "type": "string"
+                },
+                "telefone": {
+                    "type": "string"
+                }
+            }
+        },
         "models.PaginatedLegalEntities": {
             "type": "object",
             "properties": {
@@ -7265,6 +7593,12 @@
                 },
                 "nascimento_data": {
                     "type": "string"
+                },
+                "outros_tutores": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/models.OtherTutor"
+                    }
                 },
                 "pedigree_indicador": {
                     "type": "boolean"
@@ -7941,6 +8275,9 @@
         },
         "models.UserConfigOptInResponse": {
             "type": "object",
+            "required": [
+                "opt_in"
+            ],
             "properties": {
                 "category_opt_ins": {
                     "type": "object",

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -195,6 +195,13 @@ definitions:
       telefone:
         type: string
     type: object
+  models.AddCPFSecretariaRequest:
+    properties:
+      cd_ua:
+        type: string
+    required:
+    - cd_ua
+    type: object
   models.Aluno:
     properties:
       conceito:
@@ -404,6 +411,39 @@ definitions:
         type: array
       pagination:
         $ref: '#/definitions/models.PaginationInfo'
+    type: object
+  models.CPFSecretariaListResponse:
+    properties:
+      cpf:
+        type: string
+      mappings:
+        items:
+          $ref: '#/definitions/models.CPFSecretariaResponse'
+        type: array
+    type: object
+  models.CPFSecretariaQueryResponse:
+    properties:
+      cd_uas:
+        items:
+          type: string
+        type: array
+      cpf:
+        type: string
+    type: object
+  models.CPFSecretariaResponse:
+    properties:
+      cd_ua:
+        type: string
+      cpf:
+        type: string
+      created_at:
+        type: string
+      created_by:
+        type: string
+      id:
+        type: string
+      updated_at:
+        type: string
     type: object
   models.CRAS:
     properties:
@@ -1000,6 +1040,17 @@ definitions:
       status:
         type: string
     type: object
+  models.OtherTutor:
+    properties:
+      cpf:
+        type: string
+      email:
+        type: string
+      nome:
+        type: string
+      telefone:
+        type: string
+    type: object
   models.PaginatedLegalEntities:
     properties:
       data:
@@ -1114,6 +1165,10 @@ definitions:
         type: string
       nascimento_data:
         type: string
+      outros_tutores:
+        items:
+          $ref: '#/definitions/models.OtherTutor'
+        type: array
       pedigree_indicador:
         type: boolean
       pedigree_origem_nome:
@@ -1564,6 +1619,8 @@ definitions:
         type: object
       opt_in:
         type: boolean
+    required:
+    - opt_in
     type: object
   models.UserConfigResponse:
     properties:
@@ -2185,6 +2242,136 @@ paths:
       summary: Ler chave arbitrária do cache Redis
       tags:
       - admin
+  /admin/cpf-secretaria/{cpf}:
+    get:
+      description: Retorna todos os vínculos de secretaria associados a um CPF na
+        base de apoio.
+      parameters:
+      - description: CPF do usuário (11 dígitos)
+        in: path
+        name: cpf
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/models.CPFSecretariaListResponse'
+        "401":
+          description: Unauthorized
+          schema:
+            $ref: '#/definitions/handlers.ErrorResponse'
+        "403":
+          description: Forbidden
+          schema:
+            $ref: '#/definitions/handlers.ErrorResponse'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/handlers.ErrorResponse'
+      security:
+      - BearerAuth: []
+      summary: Listar vínculos CPF-Secretaria
+      tags:
+      - admin
+      - cpf-secretaria
+    post:
+      consumes:
+      - application/json
+      description: Vincula um CPF a uma secretaria (cd_ua SICI) na base de apoio.
+        Um CPF pode ter múltiplos vínculos.
+      parameters:
+      - description: CPF do usuário (11 dígitos)
+        in: path
+        name: cpf
+        required: true
+        type: string
+      - description: cd_ua da secretaria
+        in: body
+        name: data
+        required: true
+        schema:
+          $ref: '#/definitions/models.AddCPFSecretariaRequest'
+      produces:
+      - application/json
+      responses:
+        "201":
+          description: Created
+          schema:
+            $ref: '#/definitions/models.CPFSecretariaResponse'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/handlers.ErrorResponse'
+        "401":
+          description: Unauthorized
+          schema:
+            $ref: '#/definitions/handlers.ErrorResponse'
+        "403":
+          description: Forbidden
+          schema:
+            $ref: '#/definitions/handlers.ErrorResponse'
+        "409":
+          description: Conflict
+          schema:
+            $ref: '#/definitions/handlers.ErrorResponse'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/handlers.ErrorResponse'
+      security:
+      - BearerAuth: []
+      summary: Adicionar vínculo CPF-Secretaria
+      tags:
+      - admin
+      - cpf-secretaria
+  /admin/cpf-secretaria/{cpf}/{cd_ua}:
+    delete:
+      description: Remove o vínculo entre um CPF e uma secretaria específica.
+      parameters:
+      - description: CPF do usuário (11 dígitos)
+        in: path
+        name: cpf
+        required: true
+        type: string
+      - description: Código da UA (SICI)
+        in: path
+        name: cd_ua
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "204":
+          description: No Content
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/handlers.ErrorResponse'
+        "401":
+          description: Unauthorized
+          schema:
+            $ref: '#/definitions/handlers.ErrorResponse'
+        "403":
+          description: Forbidden
+          schema:
+            $ref: '#/definitions/handlers.ErrorResponse'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/handlers.ErrorResponse'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/handlers.ErrorResponse'
+      security:
+      - BearerAuth: []
+      summary: Remover vínculo CPF-Secretaria
+      tags:
+      - admin
+      - cpf-secretaria
   /admin/notification-categories:
     post:
       consumes:
@@ -4118,6 +4305,40 @@ paths:
       summary: Obter motivos de opt-out
       tags:
       - config
+  /cpf-secretaria/{cpf}:
+    get:
+      description: Retorna a lista de cd_uas vinculados ao CPF na base de apoio. Usado
+        por outras APIs (app-go-api) via service account.
+      parameters:
+      - description: CPF do usuário (11 dígitos)
+        in: path
+        name: cpf
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/models.CPFSecretariaQueryResponse'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/handlers.ErrorResponse'
+        "401":
+          description: Unauthorized
+          schema:
+            $ref: '#/definitions/handlers.ErrorResponse'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/handlers.ErrorResponse'
+      security:
+      - BearerAuth: []
+      summary: Consultar secretarias de um CPF
+      tags:
+      - cpf-secretaria
   /departments:
     get:
       consumes:


### PR DESCRIPTION
Regenera os arquivos de documentação Swagger após o merge do PR #54 (feat/rbac-secretaria).

## O que mudou

- Adicionadas 4 novas rotas ao Swagger:
  - `GET /cpf-secretaria/{cpf}` — consulta mapeamentos por CPF (usuário autenticado)
  - `GET /admin/cpf-secretaria/{cpf}` — consulta mapeamentos por CPF (admin)
  - `POST /admin/cpf-secretaria/{cpf}` — adiciona mapeamento CPF ↔ Unidade Administrativa
  - `DELETE /admin/cpf-secretaria/{cpf}/{cd_ua}` — remove mapeamento

## Como foi gerado

```bash
just swagger
```