### PR TITLE
fix: update default ADMIN_GROUP to match Keycloak role in JWT

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -426,7 +426,7 @@ func LoadConfig() error {
 		DBBatchSize:   getEnvAsIntOrDefault("DB_BATCH_SIZE", 100),
 
 		// Authorization configuration
-		AdminGroup:            getEnvOrDefault("ADMIN_GROUP", "rmi-admin"),
+		AdminGroup:            getEnvOrDefault("ADMIN_GROUP", "heimdall-admin"),
 		TrustedServiceClients: parseCommaSeparatedList(getEnvOrDefault("TRUSTED_SERVICE_CLIENTS", "")),
 
 		// Index maintenance configuration

--- a/internal/handlers/citizen_helpers_test.go
+++ b/internal/handlers/citizen_helpers_test.go
@@ -23,12 +23,12 @@ func TestBuildAddressString(t *testing.T) {
 		{
 			name: "complete address with all fields",
 			endereco: &models.EnderecoPrincipal{
-				Logradouro: strPtr("Rua das Flores"),
-				Numero:     strPtr("123"),
+				Logradouro:  strPtr("Rua das Flores"),
+				Numero:      strPtr("123"),
 				Complemento: strPtr("Apto 401"),
-				Bairro:     strPtr("Centro"),
-				Municipio:  strPtr("Rio de Janeiro"),
-				Estado:     strPtr("RJ"),
+				Bairro:      strPtr("Centro"),
+				Municipio:   strPtr("Rio de Janeiro"),
+				Estado:      strPtr("RJ"),
 			},
 			expected: "Rua das Flores, 123, Apto 401, Centro, Rio de Janeiro, RJ",
 		},

--- a/tests/testhelpers.go
+++ b/tests/testhelpers.go
@@ -117,7 +117,7 @@ func SetupTestContainers(t *testing.T) *TestContainers {
 	config.AppConfig.VerificationQueueSize = 100
 	config.AppConfig.DBWorkerCount = 5
 	config.AppConfig.DBBatchSize = 50
-	config.AppConfig.AdminGroup = "rmi-admin"
+	config.AppConfig.AdminGroup = "heimdall-admin"
 	config.AppConfig.WhatsAppEnabled = false
 	config.AppConfig.CFLookupEnabled = false
 


### PR DESCRIPTION
## ⚠️ Atenção — Alteração de configuração de autorização

Esta PR corrige um bug onde endpoints `/admin/cpf-secretaria` retornavam `403 Forbidden` mesmo para usuários com role de admin válida no JWT.

### Causa raiz

O middleware `RequireAdmin()` comparava as roles do token com o valor da variável de ambiente `ADMIN_GROUP`, cujo padrão era `"rmi-admin"`. Essa role **não existe** nos tokens emitidos pelo Keycloak — as roles presentes em `resource_access.superapp.roles` são `go:admin`, `heimdall-admin` e `admin:login`.

### O que mudou

O valor padrão de `ADMIN_GROUP` foi alterado de `"rmi-admin"` para `"heimdall-admin"` em `internal/config/config.go`.

> **Ambientes que definem `ADMIN_GROUP` explicitamente via variável de ambiente não são afetados.** A mudança só impacta ambientes que dependem do valor padrão.
