### PR TITLE
feat(verification): add Salesforce Marketing Cloud OTP provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,14 @@ API para gerenciamento de dados de cidadãos do Rio de Janeiro, incluindo autode
 | WHATSAPP_HSM_ID | ID do template HSM do WhatsApp | - | Sim |
 | WHATSAPP_COST_CENTER_ID | ID do centro de custo do WhatsApp | - | Sim |
 | WHATSAPP_CAMPAIGN_NAME | Nome da campanha do WhatsApp | - | Sim |
+| VERIFICATION_PROVIDER | Provedor de disparo do código OTP (`wetalkie` ou `salesforce`) | wetalkie | Não |
+| SFMC_ENABLED | Habilita/desabilita o envio via Salesforce Marketing Cloud | true | Não |
+| SFMC_SUBDOMAIN | Subdomínio do tenant do Marketing Cloud (ex: `mcpv1-xxxx`) | - | Sim (se salesforce) |
+| SFMC_CLIENT_ID | Client ID da API do Marketing Cloud | - | Sim (se salesforce) |
+| SFMC_CLIENT_SECRET | Client Secret da API do Marketing Cloud | - | Sim (se salesforce) |
+| SFMC_ACCOUNT_ID | Account ID (MID) do Marketing Cloud | - | Sim (se salesforce) |
+| SFMC_DEFINITION_KEY | Definition Key da OTT definition do Marketing Cloud | - | Sim (se salesforce) |
+| SFMC_OTP_ATTRIBUTE | Nome do atributo do código OTP no payload OTT | codigo_otp | Não |
 | MCP_SERVER_URL | URL do servidor MCP para lookup de CF | https://services.pref.rio/mcp/mcp/ | Não |
 | MCP_AUTH_TOKEN | Token de autenticação do servidor MCP | - | Não* |
 | CF_LOOKUP_COLLECTION | Nome da coleção de lookups de CF | cf_lookups | Não |

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,6 +22,13 @@ services:
       - WHATSAPP_HSM_ID=test
       - WHATSAPP_COST_CENTER_ID=test
       - WHATSAPP_CAMPAIGN_NAME=test
+      - VERIFICATION_PROVIDER=wetalkie
+      - SFMC_ENABLED=false
+      - SFMC_SUBDOMAIN=mcpv1-example
+      - SFMC_CLIENT_ID=test
+      - SFMC_CLIENT_SECRET=test
+      - SFMC_ACCOUNT_ID=test
+      - SFMC_DEFINITION_KEY=PREFRIO-OTT-DEFINITION-TEST
     networks:
       - rmi-network
     restart: unless-stopped
@@ -52,6 +59,13 @@ services:
       - WHATSAPP_HSM_ID=test
       - WHATSAPP_COST_CENTER_ID=test
       - WHATSAPP_CAMPAIGN_NAME=test
+      - VERIFICATION_PROVIDER=wetalkie
+      - SFMC_ENABLED=false
+      - SFMC_SUBDOMAIN=mcpv1-example
+      - SFMC_CLIENT_ID=test
+      - SFMC_CLIENT_SECRET=test
+      - SFMC_ACCOUNT_ID=test
+      - SFMC_DEFINITION_KEY=PREFRIO-OTT-DEFINITION-TEST
     networks:
       - rmi-network
     restart: unless-stopped

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -8,6 +8,13 @@ import (
 	"time"
 )
 
+const (
+	// VerificationProviderWetalkie routes OTP dispatch through the legacy Wetalkie HSM API.
+	VerificationProviderWetalkie = "wetalkie"
+	// VerificationProviderSalesforce routes OTP dispatch through the Salesforce Marketing Cloud OTT API.
+	VerificationProviderSalesforce = "salesforce"
+)
+
 // Config holds all configuration values
 type Config struct {
 	// Server configuration
@@ -94,6 +101,18 @@ type Config struct {
 	WhatsAppHSMID        string `json:"whatsapp_hsm_id"`
 	WhatsAppCostCenterID string `json:"whatsapp_cost_center_id"`
 	WhatsAppCampaignName string `json:"whatsapp_campaign_name"`
+
+	// Verification provider selection (wetalkie | salesforce)
+	VerificationProvider string `json:"verification_provider"`
+
+	// Salesforce Marketing Cloud (OTT) configuration
+	SFMCEnabled       bool   `json:"sfmc_enabled"`
+	SFMCSubdomain     string `json:"sfmc_subdomain"`
+	SFMCClientID      string `json:"sfmc_client_id"`
+	SFMCClientSecret  string `json:"sfmc_client_secret"`
+	SFMCAccountID     string `json:"sfmc_account_id"`
+	SFMCDefinitionKey string `json:"sfmc_definition_key"`
+	SFMCOTPAttribute  string `json:"sfmc_otp_attribute"`
 
 	// Tracing configuration
 	TracingEnabled  bool   `json:"tracing_enabled"`
@@ -305,6 +324,48 @@ func LoadConfig() error {
 		return fmt.Errorf("WHATSAPP_CAMPAIGN_NAME is required")
 	}
 
+	verificationProvider := strings.ToLower(getEnvOrDefault("VERIFICATION_PROVIDER", VerificationProviderWetalkie))
+	switch verificationProvider {
+	case VerificationProviderWetalkie, VerificationProviderSalesforce:
+	default:
+		return fmt.Errorf("invalid VERIFICATION_PROVIDER %q: must be %q or %q", verificationProvider, VerificationProviderWetalkie, VerificationProviderSalesforce)
+	}
+
+	sfmcEnabled, err := strconv.ParseBool(getEnvOrDefault("SFMC_ENABLED", "true"))
+	if err != nil {
+		return fmt.Errorf("invalid SFMC_ENABLED value: %w", err)
+	}
+
+	sfmcSubdomain := os.Getenv("SFMC_SUBDOMAIN")
+	sfmcClientID := os.Getenv("SFMC_CLIENT_ID")
+	sfmcClientSecret := os.Getenv("SFMC_CLIENT_SECRET")
+	sfmcAccountID := os.Getenv("SFMC_ACCOUNT_ID")
+	sfmcDefinitionKey := os.Getenv("SFMC_DEFINITION_KEY")
+	sfmcOTPAttribute := getEnvOrDefault("SFMC_OTP_ATTRIBUTE", "codigo_otp")
+
+	// Require SFMC credentials only when Salesforce is active, so Wetalkie deployments boot unchanged.
+	if verificationProvider == VerificationProviderSalesforce {
+		var missing []string
+		if sfmcSubdomain == "" {
+			missing = append(missing, "SFMC_SUBDOMAIN")
+		}
+		if sfmcClientID == "" {
+			missing = append(missing, "SFMC_CLIENT_ID")
+		}
+		if sfmcClientSecret == "" {
+			missing = append(missing, "SFMC_CLIENT_SECRET")
+		}
+		if sfmcAccountID == "" {
+			missing = append(missing, "SFMC_ACCOUNT_ID")
+		}
+		if sfmcDefinitionKey == "" {
+			missing = append(missing, "SFMC_DEFINITION_KEY")
+		}
+		if len(missing) > 0 {
+			return fmt.Errorf("VERIFICATION_PROVIDER=salesforce requires: %s", strings.Join(missing, ", "))
+		}
+	}
+
 	indexMaintenanceInterval, err := time.ParseDuration(getEnvOrDefault("INDEX_MAINTENANCE_INTERVAL", "1h"))
 	if err != nil {
 		return fmt.Errorf("invalid INDEX_MAINTENANCE_INTERVAL: %w", err)
@@ -405,6 +466,16 @@ func LoadConfig() error {
 		WhatsAppHSMID:        whatsappHSMID,
 		WhatsAppCostCenterID: whatsappCostCenterID,
 		WhatsAppCampaignName: whatsappCampaignName,
+
+		VerificationProvider: verificationProvider,
+
+		SFMCEnabled:       sfmcEnabled,
+		SFMCSubdomain:     sfmcSubdomain,
+		SFMCClientID:      sfmcClientID,
+		SFMCClientSecret:  sfmcClientSecret,
+		SFMCAccountID:     sfmcAccountID,
+		SFMCDefinitionKey: sfmcDefinitionKey,
+		SFMCOTPAttribute:  sfmcOTPAttribute,
 
 		// Tracing configuration
 		TracingEnabled:  getEnvOrDefault("TRACING_ENABLED", "false") == "true",

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1176,3 +1176,75 @@ func setupMinimalEnv(t *testing.T) {
 		os.Unsetenv("CF_LOOKUP_ENABLED")
 	})
 }
+
+func TestLoadConfig_DefaultsToWetalkie(t *testing.T) {
+	originalConfig := AppConfig
+	defer func() { AppConfig = originalConfig }()
+
+	setupMinimalEnv(t)
+
+	if err := LoadConfig(); err != nil {
+		t.Fatalf("LoadConfig() error = %v, want nil", err)
+	}
+	if AppConfig.VerificationProvider != VerificationProviderWetalkie {
+		t.Errorf("VerificationProvider = %v, want %v (default)", AppConfig.VerificationProvider, VerificationProviderWetalkie)
+	}
+}
+
+func TestLoadConfig_InvalidVerificationProvider(t *testing.T) {
+	originalConfig := AppConfig
+	defer func() { AppConfig = originalConfig }()
+
+	setupMinimalEnv(t)
+	t.Setenv("VERIFICATION_PROVIDER", "twilio")
+
+	err := LoadConfig()
+	if err == nil {
+		t.Fatal("LoadConfig() should return error for invalid VERIFICATION_PROVIDER")
+	}
+	if !strings.Contains(err.Error(), "invalid VERIFICATION_PROVIDER") {
+		t.Errorf("LoadConfig() error = %v, want error containing 'invalid VERIFICATION_PROVIDER'", err)
+	}
+}
+
+func TestLoadConfig_SalesforceRequiresCredentials(t *testing.T) {
+	originalConfig := AppConfig
+	defer func() { AppConfig = originalConfig }()
+
+	setupMinimalEnv(t)
+	t.Setenv("VERIFICATION_PROVIDER", "salesforce")
+
+	err := LoadConfig()
+	if err == nil {
+		t.Fatal("LoadConfig() should return error when salesforce provider lacks credentials")
+	}
+	if !strings.Contains(err.Error(), "SFMC_SUBDOMAIN") {
+		t.Errorf("LoadConfig() error = %v, want error listing missing SFMC_SUBDOMAIN", err)
+	}
+}
+
+func TestLoadConfig_SalesforceSuccess(t *testing.T) {
+	originalConfig := AppConfig
+	defer func() { AppConfig = originalConfig }()
+
+	setupMinimalEnv(t)
+	t.Setenv("VERIFICATION_PROVIDER", "salesforce")
+	t.Setenv("SFMC_SUBDOMAIN", "mcpv1-test")
+	t.Setenv("SFMC_CLIENT_ID", "cid")
+	t.Setenv("SFMC_CLIENT_SECRET", "secret")
+	t.Setenv("SFMC_ACCOUNT_ID", "534019838")
+	t.Setenv("SFMC_DEFINITION_KEY", "PREFRIO-OTT-DEFINITION-TEST")
+
+	if err := LoadConfig(); err != nil {
+		t.Fatalf("LoadConfig() error = %v, want nil", err)
+	}
+	if AppConfig.VerificationProvider != VerificationProviderSalesforce {
+		t.Errorf("VerificationProvider = %v, want %v", AppConfig.VerificationProvider, VerificationProviderSalesforce)
+	}
+	if AppConfig.SFMCOTPAttribute != "codigo_otp" {
+		t.Errorf("SFMCOTPAttribute = %v, want codigo_otp (default)", AppConfig.SFMCOTPAttribute)
+	}
+	if AppConfig.SFMCSubdomain != "mcpv1-test" {
+		t.Errorf("SFMCSubdomain = %v, want mcpv1-test", AppConfig.SFMCSubdomain)
+	}
+}

--- a/internal/utils/database.go
+++ b/internal/utils/database.go
@@ -166,7 +166,7 @@ func CreatePhoneVerification(ctx context.Context, data PhoneVerificationData) er
 	// First, try to send WhatsApp message
 	if data.DDI != "" && data.Valor != "" {
 		phone := fmt.Sprintf("%s%s%s", data.DDI, data.DDD, data.Valor)
-		if err := SendVerificationCode(ctx, phone, data.Code); err != nil {
+		if err := SendVerificationCode(ctx, data.CPF, phone, data.Code); err != nil {
 			logger.Error("failed to send WhatsApp message", zap.Error(err))
 			return fmt.Errorf("failed to send verification code: %w", err)
 		}

--- a/internal/utils/marketing_cloud.go
+++ b/internal/utils/marketing_cloud.go
@@ -1,0 +1,186 @@
+package utils
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"time"
+
+	"github.com/prefeitura-rio/app-rmi/internal/config"
+	"github.com/prefeitura-rio/app-rmi/internal/logging"
+	"github.com/prefeitura-rio/app-rmi/internal/observability"
+	"github.com/prefeitura-rio/app-rmi/internal/utils/httpclient"
+	"go.uber.org/zap"
+)
+
+const sfmcTokenCacheKey = "sfmc:token"
+
+type sfmcTokenResponse struct {
+	AccessToken string `json:"access_token"`
+	ExpiresIn   int    `json:"expires_in"`
+}
+
+type sfmcRecipient struct {
+	ContactKey string            `json:"contactKey"`
+	To         string            `json:"to"`
+	Attributes map[string]string `json:"attributes"`
+}
+
+type sfmcMessageRequest struct {
+	DefinitionKey string          `json:"definitionKey"`
+	Recipients    []sfmcRecipient `json:"recipients"`
+}
+
+func buildSFMCMessageRequest(definitionKey, otpAttribute, contactKey, phone, code string) sfmcMessageRequest {
+	return sfmcMessageRequest{
+		DefinitionKey: definitionKey,
+		Recipients: []sfmcRecipient{
+			{
+				ContactKey: contactKey,
+				To:         phone,
+				Attributes: map[string]string{otpAttribute: code},
+			},
+		},
+	}
+}
+
+// getMarketingCloudToken gets a Salesforce Marketing Cloud OAuth token, using Redis for caching.
+func getMarketingCloudToken(ctx context.Context) (string, error) {
+	logger := logging.GetLogger().With(zap.String("operation", "get_sfmc_token"))
+
+	token, err := config.Redis.Get(ctx, sfmcTokenCacheKey).Result()
+	if err == nil {
+		observability.CacheHits.WithLabelValues("sfmc_token").Inc()
+		return token, nil
+	}
+
+	authURL := fmt.Sprintf("https://%s.auth.marketingcloudapis.com/v2/token", config.AppConfig.SFMCSubdomain)
+	authBody := map[string]string{
+		"grant_type":    "client_credentials",
+		"client_id":     config.AppConfig.SFMCClientID,
+		"client_secret": config.AppConfig.SFMCClientSecret,
+		"account_id":    config.AppConfig.SFMCAccountID,
+	}
+
+	jsonBody, err := json.Marshal(authBody)
+	if err != nil {
+		logger.Error("failed to marshal SFMC auth request", zap.Error(err))
+		return "", fmt.Errorf("failed to marshal SFMC auth request: %w", err)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, authURL, bytes.NewBuffer(jsonBody))
+	if err != nil {
+		logger.Error("failed to create SFMC auth request", zap.Error(err))
+		return "", fmt.Errorf("failed to create SFMC auth request: %w", err)
+	}
+	req.Header.Set("accept", "application/json")
+	req.Header.Set("Content-Type", "application/json")
+
+	client := httpclient.GetGlobalPool().Get()
+	defer httpclient.GetGlobalPool().Put(client)
+
+	resp, err := client.Do(req)
+	if err != nil {
+		logger.Error("failed to send SFMC auth request", zap.Error(err))
+		return "", fmt.Errorf("failed to send SFMC auth request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		logger.Error("failed to read SFMC auth response body", zap.Error(err))
+		return "", fmt.Errorf("failed to read SFMC auth response body: %w", err)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("SFMC auth request failed with status: %d", resp.StatusCode)
+	}
+
+	var authResp sfmcTokenResponse
+	if err := json.Unmarshal(body, &authResp); err != nil {
+		logger.Error("failed to decode SFMC auth response", zap.Error(err))
+		return "", fmt.Errorf("failed to decode SFMC auth response: %w", err)
+	}
+	if authResp.AccessToken == "" {
+		return "", fmt.Errorf("SFMC auth response missing access_token")
+	}
+
+	// Cache with a 1-minute safety margin so a token is never used past its expiry.
+	ttl := time.Duration(authResp.ExpiresIn)*time.Second - time.Minute
+	if ttl > 0 {
+		if err := config.Redis.Set(ctx, sfmcTokenCacheKey, authResp.AccessToken, ttl).Err(); err != nil {
+			logger.Warn("failed to cache SFMC token", zap.Error(err))
+		}
+	}
+
+	return authResp.AccessToken, nil
+}
+
+// SendMarketingCloudOTP sends a single OTP code via the Salesforce Marketing Cloud OTT API.
+func SendMarketingCloudOTP(ctx context.Context, contactKey, phone, code string) error {
+	logger := logging.GetLogger().With(
+		zap.String("phone", phone),
+		zap.String("provider", config.VerificationProviderSalesforce),
+	)
+
+	if !config.AppConfig.SFMCEnabled {
+		logger.Info("SFMC messaging is disabled, skipping OTP send")
+		return nil
+	}
+
+	if err := validatePhoneNumber(phone); err != nil {
+		logger.Error("invalid phone number", zap.Error(err))
+		return err
+	}
+
+	token, err := getMarketingCloudToken(ctx)
+	if err != nil {
+		logger.Error("failed to get SFMC token", zap.Error(err))
+		return fmt.Errorf("failed to get SFMC token: %w", err)
+	}
+
+	msgReq := buildSFMCMessageRequest(config.AppConfig.SFMCDefinitionKey, config.AppConfig.SFMCOTPAttribute, contactKey, phone, code)
+
+	jsonBody, err := json.Marshal(msgReq)
+	if err != nil {
+		logger.Error("failed to marshal SFMC message request", zap.Error(err))
+		return fmt.Errorf("failed to marshal SFMC message request: %w", err)
+	}
+
+	url := fmt.Sprintf("https://%s.rest.marketingcloudapis.com/messaging/v1/ott/messages/", config.AppConfig.SFMCSubdomain)
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewBuffer(jsonBody))
+	if err != nil {
+		logger.Error("failed to create SFMC message request", zap.Error(err))
+		return fmt.Errorf("failed to create SFMC message request: %w", err)
+	}
+	req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", token))
+	req.Header.Set("Content-Type", "application/json")
+
+	client := httpclient.GetGlobalPool().Get()
+	defer httpclient.GetGlobalPool().Put(client)
+
+	resp, err := client.Do(req)
+	if err != nil {
+		logger.Error("failed to send SFMC message request", zap.Error(err))
+		return fmt.Errorf("failed to send SFMC message request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		logger.Error("failed to read SFMC response body", zap.Error(err))
+		return fmt.Errorf("failed to read SFMC response body: %w", err)
+	}
+
+	if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {
+		logger.Error("SFMC message request failed",
+			zap.Int("status_code", resp.StatusCode),
+			zap.String("response_body", string(body)))
+		return fmt.Errorf("SFMC message request failed with status: %d", resp.StatusCode)
+	}
+
+	return nil
+}

--- a/internal/utils/marketing_cloud_test.go
+++ b/internal/utils/marketing_cloud_test.go
@@ -1,0 +1,49 @@
+package utils
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/prefeitura-rio/app-rmi/internal/config"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBuildSFMCMessageRequest_ContractMatchesDoc(t *testing.T) {
+	req := buildSFMCMessageRequest("PREFRIO-OTT-DEFINITION-TEST", "codigo_otp", "12345678900", "5521999999999", "123456")
+
+	body, err := json.Marshal(req)
+	require.NoError(t, err)
+
+	expected := `{"definitionKey":"PREFRIO-OTT-DEFINITION-TEST","recipients":[{"contactKey":"12345678900","to":"5521999999999","attributes":{"codigo_otp":"123456"}}]}`
+	assert.JSONEq(t, expected, string(body))
+}
+
+func TestBuildSFMCMessageRequest_CustomOTPAttribute(t *testing.T) {
+	req := buildSFMCMessageRequest("DEF", "otp", "cpf1", "5521988887777", "654321")
+
+	require.Len(t, req.Recipients, 1)
+	assert.Equal(t, "DEF", req.DefinitionKey)
+	assert.Equal(t, "cpf1", req.Recipients[0].ContactKey)
+	assert.Equal(t, "5521988887777", req.Recipients[0].To)
+	assert.Equal(t, "654321", req.Recipients[0].Attributes["otp"])
+}
+
+func TestSendMarketingCloudOTP_DisabledSkips(t *testing.T) {
+	original := config.AppConfig
+	defer func() { config.AppConfig = original }()
+	config.AppConfig = &config.Config{SFMCEnabled: false}
+
+	err := SendMarketingCloudOTP(context.Background(), "12345678900", "5521999999999", "123456")
+	assert.NoError(t, err)
+}
+
+func TestSendMarketingCloudOTP_InvalidPhone(t *testing.T) {
+	original := config.AppConfig
+	defer func() { config.AppConfig = original }()
+	config.AppConfig = &config.Config{SFMCEnabled: true}
+
+	err := SendMarketingCloudOTP(context.Background(), "12345678900", "invalid-phone", "123456")
+	assert.Error(t, err)
+}

--- a/internal/utils/marketing_cloud_test.go
+++ b/internal/utils/marketing_cloud_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"testing"
+	"time"
 
 	"github.com/prefeitura-rio/app-rmi/internal/config"
 	"github.com/stretchr/testify/assert"
@@ -45,5 +46,53 @@ func TestSendMarketingCloudOTP_InvalidPhone(t *testing.T) {
 	config.AppConfig = &config.Config{SFMCEnabled: true}
 
 	err := SendMarketingCloudOTP(context.Background(), "12345678900", "invalid-phone", "123456")
+	assert.Error(t, err)
+}
+
+func TestGetMarketingCloudToken_CacheHit(t *testing.T) {
+	ctx := context.Background()
+	cachedToken := "cached-test-token-12345"
+
+	require.NoError(t, config.Redis.Set(ctx, sfmcTokenCacheKey, cachedToken, time.Minute).Err())
+	defer config.Redis.Del(ctx, sfmcTokenCacheKey)
+
+	token, err := getMarketingCloudToken(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, cachedToken, token, "a cached token must be returned without calling the SFMC auth API")
+}
+
+// TestGetMarketingCloudToken_CacheMissInvalidSubdomain exercises the cache-miss branch
+// (auth body construction and HTTP request creation) using a subdomain with a control
+// character, which makes the auth URL invalid and fails fast without any network I/O.
+func TestGetMarketingCloudToken_CacheMissInvalidSubdomain(t *testing.T) {
+	ctx := context.Background()
+	require.NoError(t, config.Redis.Del(ctx, sfmcTokenCacheKey).Err())
+
+	original := config.AppConfig
+	defer func() { config.AppConfig = original }()
+	config.AppConfig = &config.Config{SFMCSubdomain: "bad\nsubdomain"}
+
+	_, err := getMarketingCloudToken(ctx)
+	assert.Error(t, err)
+}
+
+// TestSendMarketingCloudOTP_MessageRequestCreationFails exercises the message-send branch
+// of SendMarketingCloudOTP up through HTTP request creation, using a cached token (to skip
+// the auth call) and an invalid subdomain (to fail request creation without network I/O).
+func TestSendMarketingCloudOTP_MessageRequestCreationFails(t *testing.T) {
+	ctx := context.Background()
+	require.NoError(t, config.Redis.Set(ctx, sfmcTokenCacheKey, "cached-token", time.Minute).Err())
+	defer config.Redis.Del(ctx, sfmcTokenCacheKey)
+
+	original := config.AppConfig
+	defer func() { config.AppConfig = original }()
+	config.AppConfig = &config.Config{
+		SFMCEnabled:       true,
+		SFMCSubdomain:     "bad\nsubdomain",
+		SFMCDefinitionKey: "PREFRIO-OTT-DEFINITION-TEST",
+		SFMCOTPAttribute:  "codigo_otp",
+	}
+
+	err := SendMarketingCloudOTP(ctx, "12345678900", "5521999999999", "123456")
 	assert.Error(t, err)
 }

--- a/internal/utils/verification.go
+++ b/internal/utils/verification.go
@@ -17,8 +17,12 @@ func GenerateVerificationCode() string {
 	return code
 }
 
-// SendVerificationCode sends a verification code to a single phone number
-func SendVerificationCode(ctx context.Context, phone string, code string) error {
+// SendVerificationCode sends a verification code to a single phone number using the configured provider.
+func SendVerificationCode(ctx context.Context, cpf string, phone string, code string) error {
+	if config.AppConfig.VerificationProvider == config.VerificationProviderSalesforce {
+		return SendMarketingCloudOTP(ctx, cpf, phone, code)
+	}
+
 	vars := map[string]interface{}{
 		"COD": code,
 	}

--- a/internal/utils/verification_test.go
+++ b/internal/utils/verification_test.go
@@ -1,10 +1,12 @@
 package utils
 
 import (
+	"context"
 	"fmt"
 	"strconv"
 	"testing"
 
+	"github.com/prefeitura-rio/app-rmi/internal/config"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -76,6 +78,30 @@ func TestGenerateVerificationCode_Distribution(t *testing.T) {
 	uniqueRatio := float64(len(codes)) / float64(iterations)
 	assert.Greater(t, uniqueRatio, 0.8,
 		"Should have high code diversity (got %.2f%% unique)", uniqueRatio*100)
+}
+
+func TestSendVerificationCode_WetalkieProviderDisabled(t *testing.T) {
+	original := config.AppConfig
+	defer func() { config.AppConfig = original }()
+	config.AppConfig = &config.Config{
+		VerificationProvider: config.VerificationProviderWetalkie,
+		WhatsAppEnabled:      false,
+	}
+
+	err := SendVerificationCode(context.Background(), "12345678900", "5521999999999", "123456")
+	assert.NoError(t, err, "wetalkie branch should short-circuit when WhatsApp is disabled")
+}
+
+func TestSendVerificationCode_SalesforceProviderDisabled(t *testing.T) {
+	original := config.AppConfig
+	defer func() { config.AppConfig = original }()
+	config.AppConfig = &config.Config{
+		VerificationProvider: config.VerificationProviderSalesforce,
+		SFMCEnabled:          false,
+	}
+
+	err := SendVerificationCode(context.Background(), "12345678900", "5521999999999", "123456")
+	assert.NoError(t, err, "salesforce branch should short-circuit when SFMC is disabled")
 }
 
 func TestGenerateVerificationCode_NoLeadingZeros(t *testing.T) {

--- a/justfile
+++ b/justfile
@@ -124,6 +124,8 @@ test-ci:
     WHATSAPP_CAMPAIGN_NAME=${WHATSAPP_CAMPAIGN_NAME:-test} \
     WHATSAPP_COST_CENTER_ID=${WHATSAPP_COST_CENTER_ID:-1} \
     WHATSAPP_HSM_ID=${WHATSAPP_HSM_ID:-1} \
+    VERIFICATION_PROVIDER=${VERIFICATION_PROVIDER:-wetalkie} \
+    SFMC_ENABLED=${SFMC_ENABLED:-false} \
     go test -v -race -coverprofile=coverage.out ./...
 
 # Run E2E tests


### PR DESCRIPTION
## Objetivo

Migrar o envio do código OTP de verificação de WhatsApp do **Wetalkie** para o **Salesforce Marketing Cloud (OTT API)**, mantendo o caminho atual intacto e permitindo **virar a chave em runtime** (GO-LIVE 20/07), sem novo deploy de código.

## O que muda

- **Seleção de provider por env** `VERIFICATION_PROVIDER` (`wetalkie` padrão | `salesforce`). Com `wetalkie`, o comportamento é idêntico ao atual.
- **Cliente SFMC OTT** (`internal/utils/marketing_cloud.go`): token OAuth com cache no Redis (TTL = `expires_in` − 1min) e envio via `messaging/v1/ott/messages/`.
- **Switch** em `SendVerificationCode` — Salesforce quando configurado, senão o fluxo Wetalkie (HSM) inalterado.
- **CPF como `contactKey`** no disparo SFMC.
- Credenciais SFMC são exigidas **apenas** quando `VERIFICATION_PROVIDER=salesforce`, então deploys Wetalkie sobem sem alteração.

## Testes

- `go build ./...` — OK
- `just fmt` — OK
- `just lint` — arquivos deste PR limpos (issues pré-existentes em `internal/config/database.go`, não tocado)
- `go test ./internal/config/ ./internal/utils/` — provider validation + contrato de mensagem SFMC passam