### PR TITLE
fix: stop CF lookup DLQ growth and harden wallet sync path

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -279,7 +279,7 @@ func LoadConfig() error {
 		return fmt.Errorf("invalid CF_LOOKUP_GLOBAL_RATE_LIMIT: %w", err)
 	}
 
-	cfLookupSyncTimeout, err := time.ParseDuration(getEnvOrDefault("CF_LOOKUP_SYNC_TIMEOUT", "8s")) // 8 seconds for synchronous lookups
+	cfLookupSyncTimeout, err := time.ParseDuration(getEnvOrDefault("CF_LOOKUP_SYNC_TIMEOUT", "15s")) // 15 seconds for synchronous lookups
 	if err != nil {
 		return fmt.Errorf("invalid CF_LOOKUP_SYNC_TIMEOUT: %w", err)
 	}

--- a/internal/handlers/citizen.go
+++ b/internal/handlers/citizen.go
@@ -54,7 +54,16 @@ func queueCFLookupJob(ctx context.Context, cpf, address string) {
 
 	// Queue job using Redis
 	queueKey := "sync:queue:cf_lookup"
+	created, err := config.Redis.SetNX(ctx, "cf_lookup:pending:"+cpf, "1", time.Hour).Result()
+
+	if err == nil && !created {
+		logger.Debug("CF lookup job already pending, skipping",
+			zap.String("cpf", cpf))
+		return
+	}
+
 	err = config.Redis.LPush(ctx, queueKey, string(jobBytes)).Err()
+
 	if err != nil {
 		logger.Error("failed to queue CF lookup job", zap.Error(err))
 		return
@@ -2922,24 +2931,32 @@ func GetCitizenWallet(c *gin.Context) {
 				// No cached data, try synchronous CF lookup
 				logger.Info("NO CACHED CF DATA - ATTEMPTING SYNCHRONOUS LOOKUP", zap.String("cpf", cpf))
 
-				// Get citizen address for CF lookup - prioritize self-declared address directly
-				address := getSelfDeclaredAddressForCFLookup(ctx, cpf)
-				if address == "" {
-					// Fallback to extraction from citizen data
-					address = services.CFLookupServiceInstance.ExtractAddress(&citizen)
+				// Skip lookup for municipalities not covered by the MCP service
+				var municipio *string
+				if citizen.Endereco != nil && citizen.Endereco.Principal != nil {
+					municipio = citizen.Endereco.Principal.Municipio
 				}
-				logger.Info("EXTRACTED ADDRESS FOR CF LOOKUP", zap.String("address", address))
+				if services.IsMunicipioCoberto(municipio) {
+					// Get citizen address for CF lookup - prioritize self-declared address directly
+					address := getSelfDeclaredAddressForCFLookup(ctx, cpf)
+					if address == "" {
+						address = services.CFLookupServiceInstance.ExtractAddress(&citizen)
+					}
+					logger.Info("EXTRACTED ADDRESS FOR CF LOOKUP", zap.String("address", address))
 
-				if address != "" {
-					logger.Info("CALLING TrySynchronousCFLookup", zap.String("cpf", cpf), zap.String("address", address))
-					cfData, err = services.CFLookupServiceInstance.TrySynchronousCFLookup(ctx, cpf, address)
-					if err != nil {
-						logger.Info("SYNCHRONOUS CF LOOKUP FAILED", zap.Error(err), zap.String("cpf", cpf))
+					if address != "" {
+						logger.Info("CALLING TrySynchronousCFLookup", zap.String("cpf", cpf), zap.String("address", address))
+						cfData, err = services.CFLookupServiceInstance.TrySynchronousCFLookup(ctx, cpf, address)
+						if err != nil {
+							logger.Info("SYNCHRONOUS CF LOOKUP FAILED", zap.Error(err), zap.String("cpf", cpf))
+						} else {
+							logger.Info("SYNCHRONOUS CF LOOKUP RESULT", zap.Bool("cf_data_found", cfData != nil))
+						}
 					} else {
-						logger.Info("SYNCHRONOUS CF LOOKUP RESULT", zap.Bool("cf_data_found", cfData != nil))
+						logger.Info("NO ADDRESS EXTRACTED - SKIPPING CF LOOKUP", zap.String("cpf", cpf))
 					}
 				} else {
-					logger.Info("NO ADDRESS EXTRACTED - SKIPPING CF LOOKUP", zap.String("cpf", cpf))
+					logger.Debug("município não coberto pelo MCP, ignorando lookup síncrono", zap.String("cpf", cpf))
 				}
 			} else {
 				logger.Info("FOUND CACHED CF DATA", zap.String("cpf", cpf), zap.Bool("is_active", cfData.IsActive))
@@ -3451,18 +3468,18 @@ func buildAddressString(endereco *models.EnderecoPrincipal) string {
 		return ""
 	}
 
-	parts := []string{*endereco.Logradouro}
+	parts := []string{services.SanitizeAddressField(*endereco.Logradouro)}
 
 	if endereco.Numero != nil && *endereco.Numero != "" {
-		parts = append(parts, *endereco.Numero)
+		parts = append(parts, services.SanitizeAddressField(*endereco.Numero))
 	}
 
 	if endereco.Complemento != nil && *endereco.Complemento != "" {
-		parts = append(parts, *endereco.Complemento)
+		parts = append(parts, services.SanitizeAddressField(*endereco.Complemento))
 	}
 
 	if endereco.Bairro != nil && *endereco.Bairro != "" {
-		parts = append(parts, *endereco.Bairro)
+		parts = append(parts, services.SanitizeAddressField(*endereco.Bairro))
 	}
 
 	if endereco.Municipio != nil && *endereco.Municipio != "" {

--- a/internal/handlers/citizen.go
+++ b/internal/handlers/citizen.go
@@ -54,7 +54,7 @@ func queueCFLookupJob(ctx context.Context, cpf, address string) {
 
 	// Queue job using Redis
 	queueKey := "sync:queue:cf_lookup"
-	created, err := config.Redis.SetNX(ctx, "cf_lookup:pending:"+cpf, "1", time.Hour).Result()
+	created, err := config.Redis.SetNX(ctx, services.CFLookupPendingKey(cpf), "1", time.Hour).Result()
 
 	if err == nil && !created {
 		logger.Debug("CF lookup job already pending, skipping",
@@ -679,7 +679,9 @@ func UpdateSelfDeclaredAddress(c *gin.Context) {
 		if err != nil {
 			logger.Warn("failed to invalidate CF data for address change", zap.Error(err))
 		} else {
-			// Queue new CF lookup for the updated address
+			// Address changed (or no prior CF): allow a new lookup even if a pending
+			// lock still exists from a previous enqueue within the TTL window.
+			services.ClearCFLookupPending(ctx, cpf)
 			logger.Debug("queuing CF lookup for updated address", zap.String("cpf", cpf))
 			queueCFLookupJob(ctx, cpf, newAddress)
 		}
@@ -2931,17 +2933,20 @@ func GetCitizenWallet(c *gin.Context) {
 				// No cached data, try synchronous CF lookup
 				logger.Info("NO CACHED CF DATA - ATTEMPTING SYNCHRONOUS LOOKUP", zap.String("cpf", cpf))
 
-				// Skip lookup for municipalities not covered by the MCP service
+				// Gate coverage using the same address source as the lookup:
+				// self-declared when present, otherwise base citizen data.
 				var municipio *string
-				if citizen.Endereco != nil && citizen.Endereco.Principal != nil {
-					municipio = citizen.Endereco.Principal.Municipio
+				var address string
+				if selfDeclaredPrincipal := getSelfDeclaredEnderecoPrincipalForCFLookup(ctx, cpf); selfDeclaredPrincipal != nil {
+					municipio = selfDeclaredPrincipal.Municipio
+					address = buildAddressString(selfDeclaredPrincipal)
+				} else {
+					if citizen.Endereco != nil && citizen.Endereco.Principal != nil {
+						municipio = citizen.Endereco.Principal.Municipio
+					}
+					address = services.CFLookupServiceInstance.ExtractAddress(&citizen)
 				}
 				if services.IsMunicipioCoberto(municipio) {
-					// Get citizen address for CF lookup - prioritize self-declared address directly
-					address := getSelfDeclaredAddressForCFLookup(ctx, cpf)
-					if address == "" {
-						address = services.CFLookupServiceInstance.ExtractAddress(&citizen)
-					}
 					logger.Info("EXTRACTED ADDRESS FOR CF LOOKUP", zap.String("address", address))
 
 					if address != "" {
@@ -3429,9 +3434,8 @@ func getCurrentEmailData(ctx context.Context, cpf string) (*EmailDataWithTimesta
 	}, nil
 }
 
-// getSelfDeclaredAddressForCFLookup gets the current self-declared address for CF lookup
-func getSelfDeclaredAddressForCFLookup(ctx context.Context, cpf string) string {
-	// Try to get from cache first using DataManager
+// getSelfDeclaredEnderecoPrincipalForCFLookup returns the self-declared address principal if present.
+func getSelfDeclaredEnderecoPrincipalForCFLookup(ctx context.Context, cpf string) *models.EnderecoPrincipal {
 	dataManager := services.NewDataManager(config.Redis, config.MongoDB, observability.Logger())
 
 	var addressData struct {
@@ -3442,10 +3446,9 @@ func getSelfDeclaredAddressForCFLookup(ctx context.Context, cpf string) string {
 
 	err := dataManager.Read(ctx, cpf, config.AppConfig.SelfDeclaredCollection, "self_declared_address", &addressData)
 	if err == nil && addressData.Endereco != nil && addressData.Endereco.Principal != nil {
-		return buildAddressString(addressData.Endereco.Principal)
+		return addressData.Endereco.Principal
 	}
 
-	// Fallback to MongoDB with field projection (only get endereco field)
 	var selfDeclared struct {
 		Endereco *models.Endereco `bson:"endereco"`
 	}
@@ -3456,9 +3459,17 @@ func getSelfDeclaredAddressForCFLookup(ctx context.Context, cpf string) string {
 	).Decode(&selfDeclared)
 
 	if err == nil && selfDeclared.Endereco != nil && selfDeclared.Endereco.Principal != nil {
-		return buildAddressString(selfDeclared.Endereco.Principal)
+		return selfDeclared.Endereco.Principal
 	}
 
+	return nil
+}
+
+// getSelfDeclaredAddressForCFLookup gets the current self-declared address for CF lookup
+func getSelfDeclaredAddressForCFLookup(ctx context.Context, cpf string) string {
+	if principal := getSelfDeclaredEnderecoPrincipalForCFLookup(ctx, cpf); principal != nil {
+		return buildAddressString(principal)
+	}
 	return ""
 }
 

--- a/internal/handlers/citizen.go
+++ b/internal/handlers/citizen.go
@@ -2893,11 +2893,8 @@ func GetCitizenWallet(c *gin.Context) {
 
 	// Check if we need to populate CF data in saude.clinica_familia
 	ctx, cfDataSpan := utils.TraceBusinessLogic(ctx, "cf_data_integration_wallet")
-	needsCFData := false
-	if wallet.Saude == nil || wallet.Saude.ClinicaFamilia == nil ||
-		wallet.Saude.ClinicaFamilia.Indicador == nil || !*wallet.Saude.ClinicaFamilia.Indicador {
-		needsCFData = true
-	}
+	needsCFData := wallet.Saude == nil || wallet.Saude.ClinicaFamilia == nil ||
+		wallet.Saude.ClinicaFamilia.Indicador == nil || !*wallet.Saude.ClinicaFamilia.Indicador
 
 	logger.Info("WALLET CF CHECK", zap.Bool("needs_cf_data", needsCFData))
 
@@ -3463,14 +3460,6 @@ func getSelfDeclaredEnderecoPrincipalForCFLookup(ctx context.Context, cpf string
 	}
 
 	return nil
-}
-
-// getSelfDeclaredAddressForCFLookup gets the current self-declared address for CF lookup
-func getSelfDeclaredAddressForCFLookup(ctx context.Context, cpf string) string {
-	if principal := getSelfDeclaredEnderecoPrincipalForCFLookup(ctx, cpf); principal != nil {
-		return buildAddressString(principal)
-	}
-	return ""
 }
 
 // buildAddressString builds a complete address string from address components

--- a/internal/handlers/citizen_helpers_test.go
+++ b/internal/handlers/citizen_helpers_test.go
@@ -121,6 +121,17 @@ func TestBuildAddressString(t *testing.T) {
 			},
 			expected: "",
 		},
+		{
+			name: "strips parenthetical neighborhood annotation",
+			endereco: &models.EnderecoPrincipal{
+				Logradouro: strPtr("Estrada dos Bandeirantes"),
+				Numero:     strPtr("100"),
+				Bairro:     strPtr("Freguesia (Jacarepaguá)"),
+				Municipio:  strPtr("Rio de Janeiro"),
+				Estado:     strPtr("RJ"),
+			},
+			expected: "Estrada dos Bandeirantes, 100, Freguesia, Rio de Janeiro, RJ",
+		},
 	}
 
 	for _, tt := range tests {
@@ -142,23 +153,21 @@ func TestQueueCFLookupJob(t *testing.T) {
 	cpf := "12345678901"
 	address := "Rua Teste, 123, Centro, Rio de Janeiro, RJ"
 
-	// Clear any existing jobs
 	queueKey := "sync:queue:cf_lookup"
 	config.Redis.Del(ctx, queueKey)
+	config.Redis.Del(ctx, "cf_lookup:pending:"+cpf)
 
 	t.Run("successfully queue CF lookup job", func(t *testing.T) {
-		// Queue the job
+		config.Redis.Del(ctx, queueKey)
+		config.Redis.Del(ctx, "cf_lookup:pending:"+cpf)
 		queueCFLookupJob(ctx, cpf, address)
 
-		// Give it a moment to process
 		time.Sleep(10 * time.Millisecond)
 
-		// Verify job was queued
 		length, err := config.Redis.LLen(ctx, queueKey).Result()
 		require.NoError(t, err, "Should be able to check queue length")
 		assert.Equal(t, int64(1), length, "Queue should have 1 job")
 
-		// Get the job and verify its structure
 		jobJSON, err := config.Redis.RPop(ctx, queueKey).Result()
 		require.NoError(t, err, "Should be able to pop job from queue")
 
@@ -166,14 +175,12 @@ func TestQueueCFLookupJob(t *testing.T) {
 		err = json.Unmarshal([]byte(jobJSON), &job)
 		require.NoError(t, err, "Job should be valid JSON")
 
-		// Verify job fields
 		assert.Equal(t, "cf_lookup", job.Type, "Job type should be cf_lookup")
 		assert.Equal(t, cpf, job.Key, "Job key should be CPF")
 		assert.Equal(t, "cf_lookup", job.Collection, "Job collection should be cf_lookup")
 		assert.Equal(t, 0, job.RetryCount, "RetryCount should be 0")
 		assert.Equal(t, 3, job.MaxRetries, "MaxRetries should be 3")
 
-		// Verify job data
 		jobData, ok := job.Data.(map[string]interface{})
 		require.True(t, ok, "Job data should be a map")
 		assert.Equal(t, cpf, jobData["cpf"], "Job data should contain CPF")
@@ -181,19 +188,35 @@ func TestQueueCFLookupJob(t *testing.T) {
 	})
 
 	t.Run("queue multiple jobs", func(t *testing.T) {
-		// Clear queue
+		cpfs := []string{"11111111111", "22222222222", "33333333333"}
 		config.Redis.Del(ctx, queueKey)
+		for _, c := range cpfs {
+			config.Redis.Del(ctx, "cf_lookup:pending:"+c)
+		}
 
-		// Queue multiple jobs
-		queueCFLookupJob(ctx, "11111111111", "Address 1")
-		queueCFLookupJob(ctx, "22222222222", "Address 2")
-		queueCFLookupJob(ctx, "33333333333", "Address 3")
+		queueCFLookupJob(ctx, cpfs[0], "Address 1")
+		queueCFLookupJob(ctx, cpfs[1], "Address 2")
+		queueCFLookupJob(ctx, cpfs[2], "Address 3")
 
 		time.Sleep(10 * time.Millisecond)
 
-		// Verify all jobs queued
 		length, err := config.Redis.LLen(ctx, queueKey).Result()
 		require.NoError(t, err, "Should be able to check queue length")
 		assert.Equal(t, int64(3), length, "Queue should have 3 jobs")
+	})
+
+	t.Run("skips duplicate job for same CPF while pending", func(t *testing.T) {
+		dupCPF := "44444444444"
+		config.Redis.Del(ctx, queueKey)
+		config.Redis.Del(ctx, "cf_lookup:pending:"+dupCPF)
+
+		queueCFLookupJob(ctx, dupCPF, "Address A")
+		queueCFLookupJob(ctx, dupCPF, "Address B")
+
+		time.Sleep(10 * time.Millisecond)
+
+		length, err := config.Redis.LLen(ctx, queueKey).Result()
+		require.NoError(t, err)
+		assert.Equal(t, int64(1), length, "Only one job should be queued while pending")
 	})
 }

--- a/internal/services/cf_lookup_service.go
+++ b/internal/services/cf_lookup_service.go
@@ -89,15 +89,15 @@ func (s *CFLookupService) ShouldLookupCF(ctx context.Context, cpf string, citize
 		return false, "", nil
 	}
 
-	if citizenData.Endereco != nil && citizenData.Endereco.Principal != nil {
-		if !isMunicipioCoberto(citizenData.Endereco.Principal.Municipio) {
-			s.logger.Debug("município não coberto pelo MCP, ignorando lookup",
-				zap.String("cpf", cpf))
-			return false, "", nil
-		}
+	// Prefer the same address principal used for the MCP lookup (self-declared overlay
+	// when present on citizenData, otherwise base data).
+	principal := preferredAddressPrincipal(citizenData)
+	if principal != nil && !isMunicipioCoberto(principal.Municipio) {
+		s.logger.Debug("município não coberto pelo MCP, ignorando lookup",
+			zap.String("cpf", cpf))
+		return false, "", nil
 	}
 
-	// Extract address from citizen data (prioritize self-declared, then base data)
 	address := s.ExtractAddress(citizenData)
 	if address == "" {
 		s.logger.Debug("no address available for CF lookup", zap.String("cpf", cpf))
@@ -234,6 +234,9 @@ func (s *CFLookupService) PerformCFLookup(ctx context.Context, cpf, address stri
 		zap.Int("distance_meters", cfLookup.DistanceMeters),
 		zap.Bool("cf_ativo", healthData.HealthFacility.Ativo),
 		zap.Bool("cf_aberto_publico", healthData.HealthFacility.AbertoAoPublico))
+
+	// Allow a new background job (e.g. after address change) without waiting for TTL.
+	ClearCFLookupPending(ctx, cpf)
 
 	return nil
 }
@@ -649,6 +652,8 @@ func (s *CFLookupService) TrySynchronousCFLookup(ctx context.Context, cpf, addre
 		zap.String("cpf", cpf),
 		zap.String("cf_name", healthData.HealthFacility.NomePopular))
 
+	ClearCFLookupPending(ctx, cpf)
+
 	return cfLookup, nil
 }
 
@@ -673,7 +678,7 @@ func (s *CFLookupService) queueCFLookupJob(ctx context.Context, cpf, address str
 		return
 	}
 
-	created, err := config.Redis.SetNX(ctx, "cf_lookup:pending:"+cpf, "1", time.Hour).Result()
+	created, err := config.Redis.SetNX(ctx, CFLookupPendingKey(cpf), "1", time.Hour).Result()
 
 	if err == nil && !created {
 		s.logger.Debug("CF lookup job already pending, skipping",
@@ -692,14 +697,43 @@ func (s *CFLookupService) queueCFLookupJob(ctx context.Context, cpf, address str
 	s.logger.Debug("CF lookup job queued successfully", zap.String("job_id", job.ID))
 }
 
+// preferredAddressPrincipal returns the address principal used for CF lookup:
+// self-declared when origem is set, otherwise the base principal.
+func preferredAddressPrincipal(citizenData *models.Citizen) *models.EnderecoPrincipal {
+	if citizenData == nil || citizenData.Endereco == nil || citizenData.Endereco.Principal == nil {
+		return nil
+	}
+	return citizenData.Endereco.Principal
+}
+
 func isMunicipioCoberto(municipio *string) bool {
 	if municipio == nil || *municipio == "" {
+		// No municipality on record: system default is Rio de Janeiro.
 		return true
 	}
-	m := strings.TrimSpace(strings.ToLower(*municipio))
+	m := strings.ToLower(strings.TrimSpace(*municipio))
+	// Normalize common suffixes from non-normalized base data, e.g. "Rio de Janeiro/RJ".
+	if i := strings.IndexAny(m, "/,"); i >= 0 {
+		m = strings.TrimSpace(m[:i])
+	}
 	return m == "rio de janeiro"
 }
 
+// IsMunicipioCoberto reports whether the municipality is covered by the MCP CF service.
 func IsMunicipioCoberto(municipio *string) bool {
 	return isMunicipioCoberto(municipio)
+}
+
+// CFLookupPendingKey returns the Redis key used to dedupe CF lookup jobs per CPF.
+func CFLookupPendingKey(cpf string) string {
+	return "cf_lookup:pending:" + cpf
+}
+
+// ClearCFLookupPending removes the per-CPF pending lock so a new job can be enqueued
+// (e.g. after a successful lookup or an address change).
+func ClearCFLookupPending(ctx context.Context, cpf string) {
+	if config.Redis == nil || cpf == "" {
+		return
+	}
+	_ = config.Redis.Del(ctx, CFLookupPendingKey(cpf)).Err()
 }

--- a/internal/services/cf_lookup_service.go
+++ b/internal/services/cf_lookup_service.go
@@ -6,6 +6,7 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
+	"regexp"
 	"strings"
 	"time"
 
@@ -86,6 +87,14 @@ func (s *CFLookupService) ShouldLookupCF(ctx context.Context, cpf string, citize
 		*citizenData.Saude.ClinicaFamilia.Indicador {
 		s.logger.Debug("citizen already has CF data from base data", zap.String("cpf", cpf))
 		return false, "", nil
+	}
+
+	if citizenData.Endereco != nil && citizenData.Endereco.Principal != nil {
+		if !isMunicipioCoberto(citizenData.Endereco.Principal.Municipio) {
+			s.logger.Debug("município não coberto pelo MCP, ignorando lookup",
+				zap.String("cpf", cpf))
+			return false, "", nil
+		}
 	}
 
 	// Extract address from citizen data (prioritize self-declared, then base data)
@@ -357,18 +366,18 @@ func (s *CFLookupService) buildFullAddress(logradouro, numero, complemento, bair
 		return ""
 	}
 
-	parts := []string{*logradouro}
+	parts := []string{SanitizeAddressField(*logradouro)}
 
 	if numero != nil && *numero != "" {
-		parts = append(parts, *numero)
+		parts = append(parts, SanitizeAddressField(*numero))
 	}
 
 	if complemento != nil && *complemento != "" {
-		parts = append(parts, *complemento)
+		parts = append(parts, SanitizeAddressField(*complemento))
 	}
 
 	if bairro != nil && *bairro != "" {
-		parts = append(parts, *bairro)
+		parts = append(parts, SanitizeAddressField(*bairro))
 	}
 
 	if cidade != nil && *cidade != "" {
@@ -384,6 +393,15 @@ func (s *CFLookupService) buildFullAddress(logradouro, numero, complemento, bair
 	}
 
 	return strings.Join(parts, ", ")
+}
+
+// addressParensRE strips parenthetical annotations (e.g. "Freguesia (Jacarepaguá)" → "Freguesia")
+// that break MCP geocoding.
+var addressParensRE = regexp.MustCompile(`\s*\(.*?\)`)
+
+// SanitizeAddressField removes parenthetical annotations from address components before MCP lookup.
+func SanitizeAddressField(address string) string {
+	return strings.TrimSpace(addressParensRE.ReplaceAllString(address, ""))
 }
 
 // categorizeError categorizes errors for better handling and monitoring
@@ -484,14 +502,15 @@ func (s *CFLookupService) storeCFLookup(ctx context.Context, cfLookup *models.CF
 
 	update := bson.M{
 		"$set": bson.M{
-			"cpf":             cfLookup.CPF,
-			"address_hash":    cfLookup.AddressHash,
-			"address_used":    cfLookup.AddressUsed,
-			"cf_data":         cfLookup.CFData,
-			"distance_meters": cfLookup.DistanceMeters,
-			"lookup_source":   cfLookup.LookupSource,
-			"updated_at":      time.Now(),
-			"is_active":       true,
+			"cpf":               cfLookup.CPF,
+			"address_hash":      cfLookup.AddressHash,
+			"address_used":      cfLookup.AddressUsed,
+			"cf_data":           cfLookup.CFData,
+			"equipe_saude_data": cfLookup.EquipeSaudeData,
+			"distance_meters":   cfLookup.DistanceMeters,
+			"lookup_source":     cfLookup.LookupSource,
+			"updated_at":        time.Now(),
+			"is_active":         true,
 		},
 		"$setOnInsert": bson.M{
 			"_id":        cfLookup.ID,
@@ -614,11 +633,10 @@ func (s *CFLookupService) TrySynchronousCFLookup(ctx context.Context, cpf, addre
 	}
 
 	// Store in database
-	collection := s.database.Collection(config.AppConfig.CFLookupCollection)
-	_, err = collection.InsertOne(ctx, cfLookup)
+	err = s.storeCFLookup(ctx, cfLookup)
 	if err != nil {
 		s.logger.Error("failed to store synchronous CF lookup result", zap.Error(err))
-		return cfLookup, nil // Return the data even if storage failed
+		return cfLookup, nil
 	}
 
 	// Cache the result
@@ -655,6 +673,14 @@ func (s *CFLookupService) queueCFLookupJob(ctx context.Context, cpf, address str
 		return
 	}
 
+	created, err := config.Redis.SetNX(ctx, "cf_lookup:pending:"+cpf, "1", time.Hour).Result()
+
+	if err == nil && !created {
+		s.logger.Debug("CF lookup job already pending, skipping",
+			zap.String("cpf", cpf))
+		return
+	}
+
 	// Queue job using Redis
 	queueKey := "sync:queue:cf_lookup"
 	err = config.Redis.LPush(ctx, queueKey, string(jobBytes)).Err()
@@ -664,4 +690,16 @@ func (s *CFLookupService) queueCFLookupJob(ctx context.Context, cpf, address str
 	}
 
 	s.logger.Debug("CF lookup job queued successfully", zap.String("job_id", job.ID))
+}
+
+func isMunicipioCoberto(municipio *string) bool {
+	if municipio == nil || *municipio == "" {
+		return true
+	}
+	m := strings.TrimSpace(strings.ToLower(*municipio))
+	return m == "rio de janeiro"
+}
+
+func IsMunicipioCoberto(municipio *string) bool {
+	return isMunicipioCoberto(municipio)
 }

--- a/internal/services/cf_lookup_service_test.go
+++ b/internal/services/cf_lookup_service_test.go
@@ -276,6 +276,15 @@ func TestBuildFullAddress(t *testing.T) {
 			numero:     strPtr("123"),
 			wantEmpty:  true,
 		},
+		{
+			name:        "strips parenthetical neighborhood annotation",
+			logradouro:  strPtr("Estrada dos Bandeirantes"),
+			numero:      strPtr("100"),
+			bairro:      strPtr("Freguesia (Jacarepaguá)"),
+			cidade:      strPtr("Rio de Janeiro"),
+			estado:      strPtr("RJ"),
+			wantContain: []string{"Estrada dos Bandeirantes", "100", "Freguesia", "Rio de Janeiro", "RJ"},
+		},
 	}
 
 	for _, tt := range tests {
@@ -288,6 +297,8 @@ func TestBuildFullAddress(t *testing.T) {
 				for _, want := range tt.wantContain {
 					assert.Contains(t, address, want)
 				}
+				assert.NotContains(t, address, "(")
+				assert.NotContains(t, address, ")")
 			}
 		})
 	}
@@ -957,11 +968,15 @@ func TestQueueCFLookupJob(t *testing.T) {
 	defer cleanup()
 
 	ctx := context.Background()
+	cpf := "12345678901"
+	queueKey := "sync:queue:cf_lookup"
 
-	service.queueCFLookupJob(ctx, "12345678901", "Rua Test, 123")
+	config.Redis.Del(ctx, queueKey)
+	config.Redis.Del(ctx, "cf_lookup:pending:"+cpf)
+
+	service.queueCFLookupJob(ctx, cpf, "Rua Test, 123")
 
 	// Verify job was queued
-	queueKey := "sync:queue:cf_lookup"
 	jobJSON, err := config.Redis.RPop(ctx, queueKey).Result()
 	assert.NoError(t, err)
 	assert.NotEmpty(t, jobJSON)
@@ -976,7 +991,7 @@ func TestQueueCFLookupJob(t *testing.T) {
 	// Convert Data to map for access
 	dataMap, ok := job.Data.(map[string]interface{})
 	assert.True(t, ok)
-	assert.Equal(t, "12345678901", dataMap["cpf"])
+	assert.Equal(t, cpf, dataMap["cpf"])
 	assert.Equal(t, "Rua Test, 123", dataMap["address"])
 }
 

--- a/internal/services/cf_lookup_service_test.go
+++ b/internal/services/cf_lookup_service_test.go
@@ -995,6 +995,32 @@ func TestQueueCFLookupJob(t *testing.T) {
 	assert.Equal(t, "Rua Test, 123", dataMap["address"])
 }
 
+func TestIsMunicipioCoberto(t *testing.T) {
+	str := func(s string) *string { return &s }
+
+	tests := []struct {
+		name      string
+		municipio *string
+		want      bool
+	}{
+		{name: "nil assumes covered", municipio: nil, want: true},
+		{name: "empty assumes covered", municipio: str(""), want: true},
+		{name: "exact match", municipio: str("Rio de Janeiro"), want: true},
+		{name: "lowercase", municipio: str("rio de janeiro"), want: true},
+		{name: "trimmed", municipio: str("  Rio de Janeiro  "), want: true},
+		{name: "with slash suffix", municipio: str("Rio de Janeiro/RJ"), want: true},
+		{name: "with comma suffix", municipio: str("Rio de Janeiro, RJ"), want: true},
+		{name: "other city", municipio: str("Niterói"), want: false},
+		{name: "sao paulo", municipio: str("São Paulo"), want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, IsMunicipioCoberto(tt.municipio))
+		})
+	}
+}
+
 func TestTrySynchronousCFLookup_NilService(t *testing.T) {
 	var service *CFLookupService = nil
 	ctx := context.Background()

--- a/internal/services/mcp_client.go
+++ b/internal/services/mcp_client.go
@@ -505,7 +505,8 @@ func (c *MCPClient) parseHealthServicesResponse(result map[string]interface{}) (
 
 	equipamentos, ok := structuredContent["equipamentos"].([]interface{})
 	if !ok || len(equipamentos) == 0 {
-		return nil, fmt.Errorf("no equipment found in response")
+		c.logger.Debug("no equipment found in response")
+		return nil, nil
 	}
 
 	var healthResult models.HealthServicesResult

--- a/internal/services/mcp_client_test.go
+++ b/internal/services/mcp_client_test.go
@@ -811,9 +811,8 @@ func TestParseHealthServicesResponse_NoEquipment(t *testing.T) {
 
 	result, err := client.parseHealthServicesResponse(response)
 
-	assert.Error(t, err)
+	assert.NoError(t, err)
 	assert.Nil(t, result)
-	assert.Contains(t, err.Error(), "no equipment found")
 }
 
 func TestParseHealthServicesResponse_InvalidFormat(t *testing.T) {
@@ -839,17 +838,6 @@ func TestParseHealthServicesResponse_InvalidFormat(t *testing.T) {
 			},
 			errorMsg: "no structured content",
 		},
-		{
-			name: "invalid equipamentos type",
-			response: map[string]interface{}{
-				"result": map[string]interface{}{
-					"structuredContent": map[string]interface{}{
-						"equipamentos": "not an array",
-					},
-				},
-			},
-			errorMsg: "no equipment found",
-		},
 	}
 
 	for _, tt := range tests {
@@ -861,6 +849,19 @@ func TestParseHealthServicesResponse_InvalidFormat(t *testing.T) {
 			assert.Contains(t, err.Error(), tt.errorMsg)
 		})
 	}
+
+	t.Run("invalid equipamentos type", func(t *testing.T) {
+		response := map[string]interface{}{
+			"result": map[string]interface{}{
+				"structuredContent": map[string]interface{}{
+					"equipamentos": "not an array",
+				},
+			},
+		}
+		result, err := client.parseHealthServicesResponse(response)
+		assert.NoError(t, err)
+		assert.Nil(t, result)
+	})
 }
 
 func TestParseHealthServicesResponse_EquipmentWithError(t *testing.T) {


### PR DESCRIPTION
## Disclaimer

> [!WARNING]
> This PR **does not** drain the existing CF lookup dead-letter queue.
> After deploy, the backlog already in Redis must be cleared manually.

### What this PR fixes

| Issue | Fix |
| --- | --- |
| Empty MCP equipment treated as retryable error | Returns `nil, nil` (definitive miss) |
| Lookups for non-Rio municipalities | Skipped via structured municipality check |
| Duplicate jobs enqueued on every `/wallet` call | Redis `SET NX` pending key per CPF (1h TTL) |
| Race on sync persist (`InsertOne`) | Upsert via `storeCFLookup` |
| Parentheses in neighborhood names break geocoding | Address field sanitization before MCP |
| Sync lookup timeout too short | Default `CF_LOOKUP_SYNC_TIMEOUT` `8s` → `15s` |

### Out of scope

- Existing jobs in `sync:dlq:cf_lookup` are **not** removed by this change.
- Those jobs are not recoverable: “no CF for this address” is the correct final result.
- Clearing the DLQ is a **one-time production operation** after deploy.

### Post-deploy required action

```bash
redis-cli DEL sync:dlq:cf_lookup