### PR TITLE
fix(k8s): corrige hostname do Prometheus no AnalysisTemplate e KEDA

### DIFF
--- a/k8s/prod/resources.yaml
+++ b/k8s/prod/resources.yaml
@@ -195,7 +195,7 @@ spec:
   triggers:
     - type: prometheus
       metadata:
-        serverAddress: http://prometheus.istio-system.svc.cluster.local:9090
+        serverAddress: http://prometheus-server.istio-system.svc.cluster.local:9090
         metricName: http_requests_total
         threshold: "250"
         query: sum(rate(istio_requests_total{destination_workload="rmi"}[30s]))
@@ -243,7 +243,7 @@ spec:
 #   triggers:
 #     - type: prometheus
 #       metadata:
-#         serverAddress: http://prometheus.istio-system.svc.cluster.local:9090
+#         serverAddress: http://prometheus-server.istio-system.svc.cluster.local:9090
 #         metricName: rmi_sync_queue_depth
 #         threshold: "100"
 #         query: max(rmi_sync_queue_depth) by (queue)
@@ -291,7 +291,7 @@ spec:
       failureLimit: 5
       provider:
         prometheus:
-          address: http://prometheus.istio-system.svc.cluster.local:9090
+          address: http://prometheus-server.istio-system.svc.cluster.local:9090
           query: |
             (sum(rate(istio_requests_total{destination_service_name=~"{{args.service-name}}",response_code!~"5.."}[2m])) or vector(0)) / (sum(rate(istio_requests_total{destination_service_name=~"{{args.service-name}}"}[2m])) > 0) or vector(1)
     - name: error-rate
@@ -300,6 +300,6 @@ spec:
       failureLimit: 5
       provider:
         prometheus:
-          address: http://prometheus.istio-system.svc.cluster.local:9090
+          address: http://prometheus-server.istio-system.svc.cluster.local:9090
           query: |
             (sum(rate(istio_requests_total{destination_service_name=~"{{args.service-name}}",response_code=~"5.."}[2m])) or vector(0)) / (sum(rate(istio_requests_total{destination_service_name=~"{{args.service-name}}"}[2m])) > 0) or vector(0)

--- a/k8s/staging/resources.yaml
+++ b/k8s/staging/resources.yaml
@@ -171,7 +171,7 @@ spec:
   triggers:
     - type: prometheus
       metadata:
-        serverAddress: http://prometheus.istio-system.svc.cluster.local:9090
+        serverAddress: http://prometheus-server.istio-system.svc.cluster.local:9090
         metricName: http_requests_total
         threshold: "250"
         query: sum(rate(istio_requests_total{destination_workload="rmi"}[30s]))
@@ -219,7 +219,7 @@ spec:
 #   triggers:
 #     - type: prometheus
 #       metadata:
-#         serverAddress: http://prometheus.istio-system.svc.cluster.local:9090
+#         serverAddress: http://prometheus-server.istio-system.svc.cluster.local:9090
 #         metricName: rmi_sync_queue_depth
 #         threshold: "100"
 #         query: max(rmi_sync_queue_depth) by (queue)


### PR DESCRIPTION
## Problema

O release v0.2.3 falhou no step **Monitor Rollout** (run [29648318248](https://github.com/prefeitura-rio/app-rmi/actions/runs/29648318248/job/88090224203)). O Argo Rollouts abortou o canary em produção:

```
RolloutAborted: Metric "success-rate" assessed Error due to consecutiveErrors (5) > consecutiveErrorLimit (4):
dial tcp: lookup prometheus.istio-system.svc.cluster.local on 10.20.0.10:53: no such host
```

## Causa raiz

O Prometheus em `istio-system` foi migrado para o Helm chart oficial `prometheus-community/prometheus` (`helm_release.prometheus` em `infra/superapp`) há ~59 dias. Esse chart nomeia o Service como `<release>-server`, ou seja, **`prometheus-server`** — não `prometheus`. Confirmado direto no cluster de produção:

```
$ kubectl get svc -n istio-system
prometheus-server   ClusterIP   10.20.244.90   9090/TCP   59d
```

O `AnalysisTemplate rmi-success-rate` (que gateia o canary em prod) e os triggers do KEDA ainda apontavam para o hostname antigo, que não resolve mais.

Staging não pegou esse bug porque usa estratégia `blueGreen` (sem `AnalysisTemplate`/análise automática) — só o canary de prod consulta o Prometheus durante o deploy.

## Mudança

Atualiza `prometheus.istio-system` → `prometheus-server.istio-system` em:
- `k8s/prod/resources.yaml` (AnalysisTemplate success-rate/error-rate + KEDA trigger, incluindo bloco comentado)
- `k8s/staging/resources.yaml` (KEDA trigger, incluindo bloco comentado)

## Plano pós-merge

Após merge, vou disparar um novo release (v0.2.4) para reimplantar em produção e confirmar que o canary passa pela análise sem erro de DNS.