### PR TITLE
fix: reconhecer roles admin sob client id qualificado no resource_access do JWT

### DIFF
--- a/internal/handlers/admin_handlers_test.go
+++ b/internal/handlers/admin_handlers_test.go
@@ -39,7 +39,9 @@ func setupAdminHandlersTest(t *testing.T) (*gin.Engine, func()) {
 		claims := &models.JWTClaims{
 			PreferredUsername: "03561350712",
 		}
-		claims.ResourceAccess.Superapp.Roles = []string{"go:admin"}
+		claims.ResourceAccess = map[string]models.ClientAccess{
+			"superapp.apps.rio.gov.br": {Roles: []string{"go:admin"}},
+		}
 		c.Set("claims", claims)
 		c.Next()
 	}
@@ -82,9 +84,13 @@ func setupAdminHandlersTestWithAuth(t *testing.T, isAdmin bool) (*gin.Engine, fu
 			PreferredUsername: "03561350712",
 		}
 		if isAdmin {
-			claims.ResourceAccess.Superapp.Roles = []string{"go:admin"}
+			claims.ResourceAccess = map[string]models.ClientAccess{
+				"superapp.apps.rio.gov.br": {Roles: []string{"go:admin"}},
+			}
 		} else {
-			claims.ResourceAccess.Superapp.Roles = []string{"go:user"}
+			claims.ResourceAccess = map[string]models.ClientAccess{
+				"superapp.apps.rio.gov.br": {Roles: []string{"go:user"}},
+			}
 		}
 		c.Set("claims", claims)
 		c.Next()
@@ -804,21 +810,7 @@ func TestReadCacheKey_Authorization_WithMiddleware(t *testing.T) {
 			}
 
 			// Check if user has admin role
-			isAdmin := false
-			for _, role := range jwtClaims.RealmAccess.Roles {
-				if role == config.AppConfig.AdminGroup {
-					isAdmin = true
-					break
-				}
-			}
-			if !isAdmin {
-				for _, role := range jwtClaims.ResourceAccess.Superapp.Roles {
-					if role == config.AppConfig.AdminGroup {
-						isAdmin = true
-						break
-					}
-				}
-			}
+			isAdmin := jwtClaims.HasRole(config.AppConfig.AdminGroup)
 
 			if !isAdmin {
 				c.JSON(http.StatusForbidden, gin.H{"error": "Admin privileges required"})
@@ -905,21 +897,7 @@ func TestReadCacheKey_Authorization_WithMiddleware(t *testing.T) {
 			}
 
 			// Check if user has admin role
-			isAdmin := false
-			for _, role := range jwtClaims.RealmAccess.Roles {
-				if role == config.AppConfig.AdminGroup {
-					isAdmin = true
-					break
-				}
-			}
-			if !isAdmin {
-				for _, role := range jwtClaims.ResourceAccess.Superapp.Roles {
-					if role == config.AppConfig.AdminGroup {
-						isAdmin = true
-						break
-					}
-				}
-			}
+			isAdmin := jwtClaims.HasRole(config.AppConfig.AdminGroup)
 
 			if !isAdmin {
 				c.JSON(http.StatusForbidden, gin.H{"error": "Admin privileges required"})
@@ -996,21 +974,7 @@ func TestReadCacheKey_Authorization_WithMiddleware(t *testing.T) {
 			}
 
 			// Check if user has admin role
-			isAdmin := false
-			for _, role := range jwtClaims.RealmAccess.Roles {
-				if role == config.AppConfig.AdminGroup {
-					isAdmin = true
-					break
-				}
-			}
-			if !isAdmin {
-				for _, role := range jwtClaims.ResourceAccess.Superapp.Roles {
-					if role == config.AppConfig.AdminGroup {
-						isAdmin = true
-						break
-					}
-				}
-			}
+			isAdmin := jwtClaims.HasRole(config.AppConfig.AdminGroup)
 
 			if !isAdmin {
 				c.JSON(http.StatusForbidden, gin.H{"error": "Admin privileges required"})

--- a/internal/handlers/cpf_secretaria_handlers_test.go
+++ b/internal/handlers/cpf_secretaria_handlers_test.go
@@ -35,7 +35,9 @@ func setupCPFSecretariaRouter(t *testing.T) (*gin.Engine, func()) {
 
 	adminMiddleware := func(c *gin.Context) {
 		claims := &models.JWTClaims{PreferredUsername: "99999999999"}
-		claims.ResourceAccess.Superapp.Roles = []string{"go:admin"}
+		claims.ResourceAccess = map[string]models.ClientAccess{
+			"superapp.apps.rio.gov.br": {Roles: []string{"go:admin"}},
+		}
 		c.Set("claims", claims)
 		c.Next()
 	}

--- a/internal/handlers/legal_entity.go
+++ b/internal/handlers/legal_entity.go
@@ -247,13 +247,9 @@ func GetLegalEntityByCNPJ(c *gin.Context) {
 	}
 
 	// Check if user is admin
-	isAdmin := false
-	for _, role := range jwtClaims.ResourceAccess.Superapp.Roles {
-		if role == "go:admin" {
-			isAdmin = true
-			utils.AddSpanAttribute(accessSpan, "is_admin", true)
-			break
-		}
+	isAdmin := jwtClaims.HasRole("go:admin")
+	if isAdmin {
+		utils.AddSpanAttribute(accessSpan, "is_admin", true)
 	}
 
 	// If admin, allow access

--- a/internal/handlers/legal_entity_handlers_test.go
+++ b/internal/handlers/legal_entity_handlers_test.go
@@ -49,7 +49,9 @@ func adminMiddleware() gin.HandlerFunc {
 		claims := &models.JWTClaims{
 			PreferredUsername: "03561350712",
 		}
-		claims.ResourceAccess.Superapp.Roles = []string{"go:admin"}
+		claims.ResourceAccess = map[string]models.ClientAccess{
+			"superapp.apps.rio.gov.br": {Roles: []string{"go:admin"}},
+		}
 		c.Set("claims", claims)
 		c.Next()
 	}
@@ -61,7 +63,9 @@ func userMiddleware(cpf string) gin.HandlerFunc {
 		claims := &models.JWTClaims{
 			PreferredUsername: cpf,
 		}
-		claims.ResourceAccess.Superapp.Roles = []string{"user"}
+		claims.ResourceAccess = map[string]models.ClientAccess{
+			"superapp.apps.rio.gov.br": {Roles: []string{"user"}},
+		}
 		c.Set("claims", claims)
 		c.Next()
 	}
@@ -671,7 +675,9 @@ func TestGetLegalEntityByCNPJ_MissingCPFInToken(t *testing.T) {
 		claims := &models.JWTClaims{
 			PreferredUsername: "", // Empty CPF
 		}
-		claims.ResourceAccess.Superapp.Roles = []string{"user"}
+		claims.ResourceAccess = map[string]models.ClientAccess{
+			"superapp.apps.rio.gov.br": {Roles: []string{"user"}},
+		}
 		c.Set("claims", claims)
 		c.Next()
 	})

--- a/internal/handlers/test_helpers.go
+++ b/internal/handlers/test_helpers.go
@@ -48,7 +48,9 @@ func createAdminClaims(cpf string) models.JWTClaims {
 		ISS:               "test-issuer",
 		PreferredUsername: cpf,
 	}
-	claims.ResourceAccess.Superapp.Roles = []string{"go:admin"}
+	claims.ResourceAccess = map[string]models.ClientAccess{
+		"superapp.apps.rio.gov.br": {Roles: []string{"go:admin"}},
+	}
 	return claims
 }
 

--- a/internal/middleware/auth.go
+++ b/internal/middleware/auth.go
@@ -132,22 +132,7 @@ func RequireAdmin() gin.HandlerFunc {
 			return
 		}
 
-		// Check if user has admin role in RealmAccess or ResourceAccess.Superapp
-		isAdmin := false
-		for _, role := range jwtClaims.RealmAccess.Roles {
-			if role == config.AppConfig.AdminGroup {
-				isAdmin = true
-				break
-			}
-		}
-		if !isAdmin {
-			for _, role := range jwtClaims.ResourceAccess.Superapp.Roles {
-				if role == config.AppConfig.AdminGroup {
-					isAdmin = true
-					break
-				}
-			}
-		}
+		isAdmin := jwtClaims.HasRole(config.AppConfig.AdminGroup)
 
 		if !isAdmin {
 			c.JSON(http.StatusForbidden, gin.H{"error": "Admin privileges required"})
@@ -180,22 +165,7 @@ func RequireOwnCPF() gin.HandlerFunc {
 		requestedCPF := c.Param("cpf")
 		userCPF := jwtClaims.PreferredUsername
 
-		// Check if user is admin in RealmAccess or ResourceAccess.Superapp
-		isAdmin := false
-		for _, role := range jwtClaims.RealmAccess.Roles {
-			if role == config.AppConfig.AdminGroup {
-				isAdmin = true
-				break
-			}
-		}
-		if !isAdmin {
-			for _, role := range jwtClaims.ResourceAccess.Superapp.Roles {
-				if role == config.AppConfig.AdminGroup {
-					isAdmin = true
-					break
-				}
-			}
-		}
+		isAdmin := jwtClaims.HasRole(config.AppConfig.AdminGroup)
 
 		// Allow if user is admin or accessing their own data
 		if !isAdmin && requestedCPF != userCPF {
@@ -235,11 +205,8 @@ func IsAdmin(c *gin.Context) (bool, error) {
 		return false, fmt.Errorf("invalid claims type")
 	}
 
-	// Check if user has admin role
-	for _, role := range jwtClaims.RealmAccess.Roles {
-		if role == config.AppConfig.AdminGroup {
-			return true, nil
-		}
+	if jwtClaims.HasRole(config.AppConfig.AdminGroup) {
+		return true, nil
 	}
 
 	return false, nil

--- a/internal/middleware/auth_test.go
+++ b/internal/middleware/auth_test.go
@@ -138,7 +138,9 @@ func TestRequireAdmin_Success(t *testing.T) {
 		claims := &models.JWTClaims{
 			PreferredUsername: "12345678901",
 		}
-		claims.ResourceAccess.Superapp.Roles = []string{"go:admin"}
+		claims.ResourceAccess = map[string]models.ClientAccess{
+			"superapp.apps.rio.gov.br": {Roles: []string{"go:admin"}},
+		}
 		c.Set("claims", claims)
 		c.Next()
 	})
@@ -178,7 +180,9 @@ func TestRequireAdmin_NotAdmin(t *testing.T) {
 		claims := &models.JWTClaims{
 			PreferredUsername: "12345678901",
 		}
-		claims.ResourceAccess.Superapp.Roles = []string{"user"}
+		claims.ResourceAccess = map[string]models.ClientAccess{
+			"superapp.apps.rio.gov.br": {Roles: []string{"user"}},
+		}
 		c.Set("claims", claims)
 		c.Next()
 	})
@@ -248,7 +252,9 @@ func TestRequireOwnCPF_AdminAccess(t *testing.T) {
 		claims := &models.JWTClaims{
 			PreferredUsername: "12345678901",
 		}
-		claims.ResourceAccess.Superapp.Roles = []string{"go:admin"}
+		claims.ResourceAccess = map[string]models.ClientAccess{
+			"superapp.apps.rio.gov.br": {Roles: []string{"go:admin"}},
+		}
 		c.Set("claims", claims)
 		c.Next()
 	})

--- a/internal/models/jwt.go
+++ b/internal/models/jwt.go
@@ -1,5 +1,10 @@
 package models
 
+// ClientAccess holds the roles for one client entry under "resource_access".
+type ClientAccess struct {
+	Roles []string `json:"roles"`
+}
+
 // JWTClaims represents the structure of the JWT token claims
 type JWTClaims struct {
 	JTI            string      `json:"jti"`
@@ -19,25 +24,15 @@ type JWTClaims struct {
 	RealmAccess    struct {
 		Roles []string `json:"roles"`
 	} `json:"realm_access"`
-	ResourceAccess struct {
-		Broker struct {
-			Roles []string `json:"roles"`
-		} `json:"broker"`
-		Account struct {
-			Roles []string `json:"roles"`
-		} `json:"account"`
-		Superapp struct {
-			Roles []string `json:"roles"`
-		} `json:"superapp"`
-	} `json:"resource_access"`
-	Scope             string   `json:"scope"`
-	Address           struct{} `json:"address"`
-	EmailVerified     bool     `json:"email_verified"`
-	Name              string   `json:"name"`
-	PreferredUsername string   `json:"preferred_username"`
-	GivenName         string   `json:"given_name"`
-	FamilyName        string   `json:"family_name"`
-	Email             string   `json:"email"`
+	ResourceAccess    map[string]ClientAccess `json:"resource_access"`
+	Scope             string                  `json:"scope"`
+	Address           struct{}                `json:"address"`
+	EmailVerified     bool                    `json:"email_verified"`
+	Name              string                  `json:"name"`
+	PreferredUsername string                  `json:"preferred_username"`
+	GivenName         string                  `json:"given_name"`
+	FamilyName        string                  `json:"family_name"`
+	Email             string                  `json:"email"`
 }
 
 // GetAudiences returns the audience(s) as a slice of strings
@@ -59,4 +54,29 @@ func (c *JWTClaims) GetAudiences() []string {
 	default:
 		return []string{}
 	}
+}
+
+// HasResourceRole reports whether any client under resource_access grants role.
+func (c *JWTClaims) HasResourceRole(role string) bool {
+	for _, access := range c.ResourceAccess {
+		for _, r := range access.Roles {
+			if r == role {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// HasRole reports whether the token carries role as a realm role or on any
+// resource_access client. The client id is environment-specific (e.g.
+// "superapp.apps.rio.gov.br"), so all clients are scanned rather than a single
+// hardcoded key, which previously dropped roles silently.
+func (c *JWTClaims) HasRole(role string) bool {
+	for _, r := range c.RealmAccess.Roles {
+		if r == role {
+			return true
+		}
+	}
+	return c.HasResourceRole(role)
 }

--- a/internal/models/jwt_test.go
+++ b/internal/models/jwt_test.go
@@ -1,6 +1,7 @@
 package models
 
 import (
+	"encoding/json"
 	"reflect"
 	"testing"
 )
@@ -95,5 +96,37 @@ func TestGetAudiences_MixedInterfaceSlice(t *testing.T) {
 
 	if !reflect.DeepEqual(result, expected) {
 		t.Errorf("GetAudiences() with mixed types = %v, want %v", result, expected)
+	}
+}
+
+// Regression: real Keycloak tokens key resource_access on the fully-qualified
+// client id (e.g. "superapp.apps.rio.gov.br"), not the short "superapp". A fixed
+// struct hardcoded to "superapp" silently dropped these roles, so admins were
+// rejected. HasRole must find roles under any client id.
+func TestHasRole_QualifiedResourceClientID(t *testing.T) {
+	payload := `{
+		"realm_access": {"roles": ["carioca-rio"]},
+		"resource_access": {
+			"superapp.apps.rio.gov.br": {"roles": ["heimdall-admin"]},
+			"broker": {"roles": ["read-token"]}
+		}
+	}`
+
+	var claims JWTClaims
+	if err := json.Unmarshal([]byte(payload), &claims); err != nil {
+		t.Fatalf("json.Unmarshal() error = %v", err)
+	}
+
+	if !claims.HasResourceRole("heimdall-admin") {
+		t.Error("HasResourceRole(\"heimdall-admin\") = false, want true")
+	}
+	if !claims.HasRole("heimdall-admin") {
+		t.Error("HasRole(\"heimdall-admin\") = false, want true")
+	}
+	if !claims.HasRole("carioca-rio") {
+		t.Error("HasRole(\"carioca-rio\") = false, want true (realm role)")
+	}
+	if claims.HasRole("nonexistent") {
+		t.Error("HasRole(\"nonexistent\") = true, want false")
 	}
 }


### PR DESCRIPTION
## Problema

Admins reais (com a role `heimdall-admin`) tomavam **403 "Admin privileges required"** ao usar o CRUD de `/admin/cpf-secretaria/*` em produção — apesar de o token estar correto.

### Causa raiz

O struct `JWTClaims.ResourceAccess` fixava a chave `"superapp"`:

```go
Superapp struct {
    Roles []string `json:"roles"`
} `json:"superapp"`
```

Mas o client real do realm é **`superapp.apps.rio.gov.br`** (bate com o `azp` do token). Como o Go faz match exato de tag JSON, `json.Unmarshal` ignorava a chave qualificada **silenciosamente**, deixando `ResourceAccess.Superapp.Roles` sempre vazio (`nil`).

Resultado: o segundo loop do `RequireAdmin()` (o que checa `resource_access`) **nunca encontrou nada, pra ninguém**, desde que foi escrito. A única forma de passar era ter `heimdall-admin` como *realm role*, o que não acontece nesse realm (é client role). Confirmado empiricamente com um JWT real de produção.

## Fix

- **`models/jwt.go`**: `ResourceAccess` vira `map[string]ClientAccess` (dinâmico por client id) + helpers `HasRole` / `HasResourceRole` que varrem `realm_access` + **todos** os clients de `resource_access`. Assim fica robusto ao client id específico de cada ambiente (staging/prod), que era exatamente a origem do bug.
- **`middleware/auth.go`**: `RequireAdmin`, `RequireOwnCPF` e `IsAdmin` passam a usar `HasRole`. Isso corrige de quebra o `IsAdmin` (usado em phone/beta handlers), que só olhava `realm_access` e nunca `resource_access`.
- **`handlers/legal_entity.go`**: checagem `go:admin` via `HasRole` (preserva o span attribute).
- **Testes**: fixtures passam a usar a chave real `superapp.apps.rio.gov.br` (antes usavam `superapp`, que mascarava o bug) + novo teste de regressão em `jwt_test.go` que faz unmarshal de um payload realista e garante que `HasRole` enxerga a role sob o client id qualificado.

## Verificação

- `just fmt` / `just build` — OK
- `just lint` — arquivos alterados 100% limpos (há 21 issues pré-existentes em arquivos não tocados por este PR: `pet_service.go`, `phone_parsing.go`, `memory_handlers.go`, `mcp_client_test.go`, `citizen_test.go`)
- Testes unitários `internal/models` e `internal/middleware` — passam (incluindo o novo teste de regressão)
- Testes de integração dos handlers `CPFSecretaria` / `LegalEntity` / `Admin` — passam com MongoDB + Redis locais (valida o cenário real do bug: admin acessando o CRUD de cpf-secretaria)

## Escopo

Este PR resolve o caso `heimdall-admin` (client role do Keycloak) para todo mundo. O bridge separado pro Heimdall (`admin`/`superadmin` que só existem no banco do Heimdall, nunca no JWT) fica como decisão à parte, não incluída aqui.
