### PR TITLE
feat(mobilidade): conductor_id, enrich RMI e CRUD admin do catálogo

### DIFF
--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -233,6 +233,21 @@ func main() {
 			mobilidade.GET("/vehicle-colors", handlers.GetMobilidadeVehicleColors)
 		}
 
+		// Mobilidade catalog admin (protected)
+		adminMobilidade := v1.Group("/admin/mobilidade")
+		adminMobilidade.Use(middleware.AuthMiddleware(), middleware.RequireAdmin())
+		{
+			adminMobilidade.GET("/vehicle-brands", handlers.AdminListMobilidadeVehicleBrands)
+			adminMobilidade.POST("/vehicle-brands", handlers.CreateMobilidadeVehicleBrand)
+			adminMobilidade.PATCH("/vehicle-brands/:brand_id", handlers.UpdateMobilidadeVehicleBrand)
+			adminMobilidade.DELETE("/vehicle-brands/:brand_id", handlers.DeleteMobilidadeVehicleBrand)
+
+			adminMobilidade.GET("/vehicle-models", handlers.AdminListMobilidadeVehicleModels)
+			adminMobilidade.POST("/vehicle-models", handlers.CreateMobilidadeVehicleModel)
+			adminMobilidade.PATCH("/vehicle-models/:model_id", handlers.UpdateMobilidadeVehicleModel)
+			adminMobilidade.DELETE("/vehicle-models/:model_id", handlers.DeleteMobilidadeVehicleModel)
+		}
+
 		// Public citizen endpoints (no auth required)
 		public := v1.Group("/citizen")
 		{

--- a/docs/docs.go
+++ b/docs/docs.go
@@ -1100,6 +1100,546 @@ const docTemplate = `{
                 }
             }
         },
+        "/admin/mobilidade/vehicle-brands": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Lista completa de marcas do catálogo, incluindo soft-deleted (admin).",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "mobilidade"
+                ],
+                "summary": "Listar marcas (admin)",
+                "responses": {
+                    "200": {
+                        "description": "Lista tipada de marcas em data",
+                        "schema": {
+                            "$ref": "#/definitions/models.VehicleBrandsResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "Não autenticado",
+                        "schema": {
+                            "$ref": "#/definitions/handlers.ErrorResponse"
+                        }
+                    },
+                    "403": {
+                        "description": "Acesso negado",
+                        "schema": {
+                            "$ref": "#/definitions/handlers.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Erro interno",
+                        "schema": {
+                            "$ref": "#/definitions/handlers.ErrorResponse"
+                        }
+                    }
+                }
+            },
+            "post": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Cadastra uma marca no catálogo. ID gerado no backend (brand_\u0026lt;slug\u0026gt;); is_other=false.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "mobilidade"
+                ],
+                "summary": "Criar marca (admin)",
+                "parameters": [
+                    {
+                        "description": "Nome da marca",
+                        "name": "body",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/models.VehicleBrandCreateRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "description": "Marca criada",
+                        "schema": {
+                            "$ref": "#/definitions/models.VehicleBrand"
+                        }
+                    },
+                    "400": {
+                        "description": "Validação inválida",
+                        "schema": {
+                            "$ref": "#/definitions/handlers.ErrorResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "Não autenticado",
+                        "schema": {
+                            "$ref": "#/definitions/handlers.ErrorResponse"
+                        }
+                    },
+                    "403": {
+                        "description": "Acesso negado",
+                        "schema": {
+                            "$ref": "#/definitions/handlers.ErrorResponse"
+                        }
+                    },
+                    "409": {
+                        "description": "Nome ou ID já existente",
+                        "schema": {
+                            "$ref": "#/definitions/handlers.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Erro interno",
+                        "schema": {
+                            "$ref": "#/definitions/handlers.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/admin/mobilidade/vehicle-brands/{brand_id}": {
+            "delete": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Soft-delete de marca. 409 se houver modelos ativos ou veículos referenciando. Sentinel brand_outro não pode ser excluída.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "mobilidade"
+                ],
+                "summary": "Excluir marca (admin, soft-delete)",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "ID da marca",
+                        "name": "brand_id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "Marca excluída"
+                    },
+                    "400": {
+                        "description": "Sentinel ou validação",
+                        "schema": {
+                            "$ref": "#/definitions/handlers.ErrorResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "Não autenticado",
+                        "schema": {
+                            "$ref": "#/definitions/handlers.ErrorResponse"
+                        }
+                    },
+                    "403": {
+                        "description": "Acesso negado",
+                        "schema": {
+                            "$ref": "#/definitions/handlers.ErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Marca não encontrada",
+                        "schema": {
+                            "$ref": "#/definitions/handlers.ErrorResponse"
+                        }
+                    },
+                    "409": {
+                        "description": "Modelos ativos ou veículos referenciando",
+                        "schema": {
+                            "$ref": "#/definitions/handlers.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Erro interno",
+                        "schema": {
+                            "$ref": "#/definitions/handlers.ErrorResponse"
+                        }
+                    }
+                }
+            },
+            "patch": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Atualiza o nome de uma marca ativa. Sentinel brand_outro não pode ser alterada. 409 se referenciada por veículo.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "mobilidade"
+                ],
+                "summary": "Atualizar marca (admin)",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "ID da marca",
+                        "name": "brand_id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Campos a atualizar",
+                        "name": "body",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/models.VehicleBrandUpdateRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Marca atualizada",
+                        "schema": {
+                            "$ref": "#/definitions/models.VehicleBrand"
+                        }
+                    },
+                    "400": {
+                        "description": "Validação inválida ou sentinel",
+                        "schema": {
+                            "$ref": "#/definitions/handlers.ErrorResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "Não autenticado",
+                        "schema": {
+                            "$ref": "#/definitions/handlers.ErrorResponse"
+                        }
+                    },
+                    "403": {
+                        "description": "Acesso negado",
+                        "schema": {
+                            "$ref": "#/definitions/handlers.ErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Marca não encontrada",
+                        "schema": {
+                            "$ref": "#/definitions/handlers.ErrorResponse"
+                        }
+                    },
+                    "409": {
+                        "description": "Conflito (nome duplicado ou veículo referenciando)",
+                        "schema": {
+                            "$ref": "#/definitions/handlers.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Erro interno",
+                        "schema": {
+                            "$ref": "#/definitions/handlers.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/admin/mobilidade/vehicle-models": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Lista completa de modelos, incluindo soft-deleted. Filtro opcional por brand_id.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "mobilidade"
+                ],
+                "summary": "Listar modelos (admin)",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Filtrar por ID da marca",
+                        "name": "brand_id",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Lista tipada de modelos em data",
+                        "schema": {
+                            "$ref": "#/definitions/models.VehicleModelsResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "Não autenticado",
+                        "schema": {
+                            "$ref": "#/definitions/handlers.ErrorResponse"
+                        }
+                    },
+                    "403": {
+                        "description": "Acesso negado",
+                        "schema": {
+                            "$ref": "#/definitions/handlers.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Erro interno",
+                        "schema": {
+                            "$ref": "#/definitions/handlers.ErrorResponse"
+                        }
+                    }
+                }
+            },
+            "post": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Cadastra um modelo vinculado a brand_id com vehicle_type. ID gerado no backend; is_other=false.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "mobilidade"
+                ],
+                "summary": "Criar modelo (admin)",
+                "parameters": [
+                    {
+                        "description": "Dados do modelo",
+                        "name": "body",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/models.VehicleModelCreateRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "description": "Modelo criado",
+                        "schema": {
+                            "$ref": "#/definitions/models.VehicleModel"
+                        }
+                    },
+                    "400": {
+                        "description": "Validação inválida",
+                        "schema": {
+                            "$ref": "#/definitions/handlers.ErrorResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "Não autenticado",
+                        "schema": {
+                            "$ref": "#/definitions/handlers.ErrorResponse"
+                        }
+                    },
+                    "403": {
+                        "description": "Acesso negado",
+                        "schema": {
+                            "$ref": "#/definitions/handlers.ErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Marca não encontrada",
+                        "schema": {
+                            "$ref": "#/definitions/handlers.ErrorResponse"
+                        }
+                    },
+                    "409": {
+                        "description": "Nome ou ID já existente",
+                        "schema": {
+                            "$ref": "#/definitions/handlers.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Erro interno",
+                        "schema": {
+                            "$ref": "#/definitions/handlers.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/admin/mobilidade/vehicle-models/{model_id}": {
+            "delete": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Soft-delete de modelo. 409 se veículos referenciarem. Sentinel model_outro não pode ser excluído.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "mobilidade"
+                ],
+                "summary": "Excluir modelo (admin, soft-delete)",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "ID do modelo",
+                        "name": "model_id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "Modelo excluído"
+                    },
+                    "400": {
+                        "description": "Sentinel ou validação",
+                        "schema": {
+                            "$ref": "#/definitions/handlers.ErrorResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "Não autenticado",
+                        "schema": {
+                            "$ref": "#/definitions/handlers.ErrorResponse"
+                        }
+                    },
+                    "403": {
+                        "description": "Acesso negado",
+                        "schema": {
+                            "$ref": "#/definitions/handlers.ErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Modelo não encontrado",
+                        "schema": {
+                            "$ref": "#/definitions/handlers.ErrorResponse"
+                        }
+                    },
+                    "409": {
+                        "description": "Veículos referenciando",
+                        "schema": {
+                            "$ref": "#/definitions/handlers.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Erro interno",
+                        "schema": {
+                            "$ref": "#/definitions/handlers.ErrorResponse"
+                        }
+                    }
+                }
+            },
+            "patch": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Atualiza nome, vehicle_type e/ou brand_id de um modelo ativo. Sentinel model_outro não pode ser alterado. 409 se referenciado por veículo.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "mobilidade"
+                ],
+                "summary": "Atualizar modelo (admin)",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "ID do modelo",
+                        "name": "model_id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Campos a atualizar",
+                        "name": "body",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/models.VehicleModelUpdateRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Modelo atualizado",
+                        "schema": {
+                            "$ref": "#/definitions/models.VehicleModel"
+                        }
+                    },
+                    "400": {
+                        "description": "Validação inválida ou sentinel",
+                        "schema": {
+                            "$ref": "#/definitions/handlers.ErrorResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "Não autenticado",
+                        "schema": {
+                            "$ref": "#/definitions/handlers.ErrorResponse"
+                        }
+                    },
+                    "403": {
+                        "description": "Acesso negado",
+                        "schema": {
+                            "$ref": "#/definitions/handlers.ErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Modelo ou marca não encontrado",
+                        "schema": {
+                            "$ref": "#/definitions/handlers.ErrorResponse"
+                        }
+                    },
+                    "409": {
+                        "description": "Conflito (nome duplicado ou veículo referenciando)",
+                        "schema": {
+                            "$ref": "#/definitions/handlers.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Erro interno",
+                        "schema": {
+                            "$ref": "#/definitions/handlers.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
         "/admin/notification-categories": {
             "post": {
                 "security": [
@@ -3964,7 +4504,7 @@ const docTemplate = `{
                         "BearerAuth": []
                     }
                 ],
-                "description": "Retorna veículos em que o CPF é proprietário ou condutor aceito, com role em cada item.",
+                "description": "Retorna veículos em que o CPF é proprietário ou condutor aceito, com role em cada item. Quando role=conductor, inclui conductor_id (id do vínculo aceito).",
                 "consumes": [
                     "application/json"
                 ],
@@ -4112,7 +4652,7 @@ const docTemplate = `{
                         "BearerAuth": []
                     }
                 ],
-                "description": "Retorna o detalhe do veículo para proprietário ou condutor aceito (inclui invoice_photo_url, metadados de arquivos e registration_number). owner_name/owner_phone/owner_email são enriquecidos ao vivo via RMI a partir de owner_cpf.",
+                "description": "Retorna o detalhe do veículo para proprietário ou condutor aceito (inclui invoice_photo_url, metadados de arquivos e registration_number). Quando role=conductor, inclui conductor_id (id do vínculo aceito). owner_name/owner_phone/owner_email são enriquecidos ao vivo via RMI a partir de owner_cpf.",
                 "consumes": [
                     "application/json"
                 ],
@@ -9375,6 +9915,9 @@ const docTemplate = `{
         "models.VehicleBrand": {
             "type": "object",
             "properties": {
+                "deleted_at": {
+                    "type": "string"
+                },
                 "id": {
                     "type": "string",
                     "example": "brand_caloi"
@@ -9383,6 +9926,30 @@ const docTemplate = `{
                     "type": "boolean",
                     "example": false
                 },
+                "name": {
+                    "type": "string",
+                    "example": "Caloi"
+                }
+            }
+        },
+        "models.VehicleBrandCreateRequest": {
+            "type": "object",
+            "required": [
+                "name"
+            ],
+            "properties": {
+                "name": {
+                    "type": "string",
+                    "example": "Caloi"
+                }
+            }
+        },
+        "models.VehicleBrandUpdateRequest": {
+            "type": "object",
+            "required": [
+                "name"
+            ],
+            "properties": {
                 "name": {
                     "type": "string",
                     "example": "Caloi"
@@ -9550,6 +10117,10 @@ const docTemplate = `{
                 "color": {
                     "type": "string"
                 },
+                "conductor_id": {
+                    "description": "ConductorID is the accepted VehicleConductor link id when Role is conductor (same id used in DELETE/PATCH paths).",
+                    "type": "string"
+                },
                 "created_at": {
                     "type": "string"
                 },
@@ -9706,6 +10277,10 @@ const docTemplate = `{
                 "color": {
                     "type": "string"
                 },
+                "conductor_id": {
+                    "description": "ConductorID is the accepted VehicleConductor link id when Role is conductor (same id used in DELETE/PATCH paths).",
+                    "type": "string"
+                },
                 "display_name": {
                     "type": "string"
                 },
@@ -9740,6 +10315,9 @@ const docTemplate = `{
                     "type": "string",
                     "example": "brand_caloi"
                 },
+                "deleted_at": {
+                    "type": "string"
+                },
                 "id": {
                     "type": "string",
                     "example": "model_e-vibe"
@@ -9751,6 +10329,46 @@ const docTemplate = `{
                 "name": {
                     "type": "string",
                     "example": "E-Vibe"
+                },
+                "vehicle_type": {
+                    "$ref": "#/definitions/models.VehicleType"
+                }
+            }
+        },
+        "models.VehicleModelCreateRequest": {
+            "type": "object",
+            "required": [
+                "brand_id",
+                "name",
+                "vehicle_type"
+            ],
+            "properties": {
+                "brand_id": {
+                    "type": "string",
+                    "example": "brand_caloi"
+                },
+                "name": {
+                    "type": "string",
+                    "example": "E-Vibe"
+                },
+                "vehicle_type": {
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/models.VehicleType"
+                        }
+                    ],
+                    "example": "bicicleta_eletrica"
+                }
+            }
+        },
+        "models.VehicleModelUpdateRequest": {
+            "type": "object",
+            "properties": {
+                "brand_id": {
+                    "type": "string"
+                },
+                "name": {
+                    "type": "string"
                 },
                 "vehicle_type": {
                     "$ref": "#/definitions/models.VehicleType"

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -1098,6 +1098,546 @@
                 }
             }
         },
+        "/admin/mobilidade/vehicle-brands": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Lista completa de marcas do catálogo, incluindo soft-deleted (admin).",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "mobilidade"
+                ],
+                "summary": "Listar marcas (admin)",
+                "responses": {
+                    "200": {
+                        "description": "Lista tipada de marcas em data",
+                        "schema": {
+                            "$ref": "#/definitions/models.VehicleBrandsResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "Não autenticado",
+                        "schema": {
+                            "$ref": "#/definitions/handlers.ErrorResponse"
+                        }
+                    },
+                    "403": {
+                        "description": "Acesso negado",
+                        "schema": {
+                            "$ref": "#/definitions/handlers.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Erro interno",
+                        "schema": {
+                            "$ref": "#/definitions/handlers.ErrorResponse"
+                        }
+                    }
+                }
+            },
+            "post": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Cadastra uma marca no catálogo. ID gerado no backend (brand_\u0026lt;slug\u0026gt;); is_other=false.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "mobilidade"
+                ],
+                "summary": "Criar marca (admin)",
+                "parameters": [
+                    {
+                        "description": "Nome da marca",
+                        "name": "body",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/models.VehicleBrandCreateRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "description": "Marca criada",
+                        "schema": {
+                            "$ref": "#/definitions/models.VehicleBrand"
+                        }
+                    },
+                    "400": {
+                        "description": "Validação inválida",
+                        "schema": {
+                            "$ref": "#/definitions/handlers.ErrorResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "Não autenticado",
+                        "schema": {
+                            "$ref": "#/definitions/handlers.ErrorResponse"
+                        }
+                    },
+                    "403": {
+                        "description": "Acesso negado",
+                        "schema": {
+                            "$ref": "#/definitions/handlers.ErrorResponse"
+                        }
+                    },
+                    "409": {
+                        "description": "Nome ou ID já existente",
+                        "schema": {
+                            "$ref": "#/definitions/handlers.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Erro interno",
+                        "schema": {
+                            "$ref": "#/definitions/handlers.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/admin/mobilidade/vehicle-brands/{brand_id}": {
+            "delete": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Soft-delete de marca. 409 se houver modelos ativos ou veículos referenciando. Sentinel brand_outro não pode ser excluída.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "mobilidade"
+                ],
+                "summary": "Excluir marca (admin, soft-delete)",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "ID da marca",
+                        "name": "brand_id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "Marca excluída"
+                    },
+                    "400": {
+                        "description": "Sentinel ou validação",
+                        "schema": {
+                            "$ref": "#/definitions/handlers.ErrorResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "Não autenticado",
+                        "schema": {
+                            "$ref": "#/definitions/handlers.ErrorResponse"
+                        }
+                    },
+                    "403": {
+                        "description": "Acesso negado",
+                        "schema": {
+                            "$ref": "#/definitions/handlers.ErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Marca não encontrada",
+                        "schema": {
+                            "$ref": "#/definitions/handlers.ErrorResponse"
+                        }
+                    },
+                    "409": {
+                        "description": "Modelos ativos ou veículos referenciando",
+                        "schema": {
+                            "$ref": "#/definitions/handlers.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Erro interno",
+                        "schema": {
+                            "$ref": "#/definitions/handlers.ErrorResponse"
+                        }
+                    }
+                }
+            },
+            "patch": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Atualiza o nome de uma marca ativa. Sentinel brand_outro não pode ser alterada. 409 se referenciada por veículo.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "mobilidade"
+                ],
+                "summary": "Atualizar marca (admin)",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "ID da marca",
+                        "name": "brand_id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Campos a atualizar",
+                        "name": "body",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/models.VehicleBrandUpdateRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Marca atualizada",
+                        "schema": {
+                            "$ref": "#/definitions/models.VehicleBrand"
+                        }
+                    },
+                    "400": {
+                        "description": "Validação inválida ou sentinel",
+                        "schema": {
+                            "$ref": "#/definitions/handlers.ErrorResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "Não autenticado",
+                        "schema": {
+                            "$ref": "#/definitions/handlers.ErrorResponse"
+                        }
+                    },
+                    "403": {
+                        "description": "Acesso negado",
+                        "schema": {
+                            "$ref": "#/definitions/handlers.ErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Marca não encontrada",
+                        "schema": {
+                            "$ref": "#/definitions/handlers.ErrorResponse"
+                        }
+                    },
+                    "409": {
+                        "description": "Conflito (nome duplicado ou veículo referenciando)",
+                        "schema": {
+                            "$ref": "#/definitions/handlers.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Erro interno",
+                        "schema": {
+                            "$ref": "#/definitions/handlers.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/admin/mobilidade/vehicle-models": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Lista completa de modelos, incluindo soft-deleted. Filtro opcional por brand_id.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "mobilidade"
+                ],
+                "summary": "Listar modelos (admin)",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Filtrar por ID da marca",
+                        "name": "brand_id",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Lista tipada de modelos em data",
+                        "schema": {
+                            "$ref": "#/definitions/models.VehicleModelsResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "Não autenticado",
+                        "schema": {
+                            "$ref": "#/definitions/handlers.ErrorResponse"
+                        }
+                    },
+                    "403": {
+                        "description": "Acesso negado",
+                        "schema": {
+                            "$ref": "#/definitions/handlers.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Erro interno",
+                        "schema": {
+                            "$ref": "#/definitions/handlers.ErrorResponse"
+                        }
+                    }
+                }
+            },
+            "post": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Cadastra um modelo vinculado a brand_id com vehicle_type. ID gerado no backend; is_other=false.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "mobilidade"
+                ],
+                "summary": "Criar modelo (admin)",
+                "parameters": [
+                    {
+                        "description": "Dados do modelo",
+                        "name": "body",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/models.VehicleModelCreateRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "description": "Modelo criado",
+                        "schema": {
+                            "$ref": "#/definitions/models.VehicleModel"
+                        }
+                    },
+                    "400": {
+                        "description": "Validação inválida",
+                        "schema": {
+                            "$ref": "#/definitions/handlers.ErrorResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "Não autenticado",
+                        "schema": {
+                            "$ref": "#/definitions/handlers.ErrorResponse"
+                        }
+                    },
+                    "403": {
+                        "description": "Acesso negado",
+                        "schema": {
+                            "$ref": "#/definitions/handlers.ErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Marca não encontrada",
+                        "schema": {
+                            "$ref": "#/definitions/handlers.ErrorResponse"
+                        }
+                    },
+                    "409": {
+                        "description": "Nome ou ID já existente",
+                        "schema": {
+                            "$ref": "#/definitions/handlers.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Erro interno",
+                        "schema": {
+                            "$ref": "#/definitions/handlers.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/admin/mobilidade/vehicle-models/{model_id}": {
+            "delete": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Soft-delete de modelo. 409 se veículos referenciarem. Sentinel model_outro não pode ser excluído.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "mobilidade"
+                ],
+                "summary": "Excluir modelo (admin, soft-delete)",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "ID do modelo",
+                        "name": "model_id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "Modelo excluído"
+                    },
+                    "400": {
+                        "description": "Sentinel ou validação",
+                        "schema": {
+                            "$ref": "#/definitions/handlers.ErrorResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "Não autenticado",
+                        "schema": {
+                            "$ref": "#/definitions/handlers.ErrorResponse"
+                        }
+                    },
+                    "403": {
+                        "description": "Acesso negado",
+                        "schema": {
+                            "$ref": "#/definitions/handlers.ErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Modelo não encontrado",
+                        "schema": {
+                            "$ref": "#/definitions/handlers.ErrorResponse"
+                        }
+                    },
+                    "409": {
+                        "description": "Veículos referenciando",
+                        "schema": {
+                            "$ref": "#/definitions/handlers.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Erro interno",
+                        "schema": {
+                            "$ref": "#/definitions/handlers.ErrorResponse"
+                        }
+                    }
+                }
+            },
+            "patch": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Atualiza nome, vehicle_type e/ou brand_id de um modelo ativo. Sentinel model_outro não pode ser alterado. 409 se referenciado por veículo.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "mobilidade"
+                ],
+                "summary": "Atualizar modelo (admin)",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "ID do modelo",
+                        "name": "model_id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Campos a atualizar",
+                        "name": "body",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/models.VehicleModelUpdateRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Modelo atualizado",
+                        "schema": {
+                            "$ref": "#/definitions/models.VehicleModel"
+                        }
+                    },
+                    "400": {
+                        "description": "Validação inválida ou sentinel",
+                        "schema": {
+                            "$ref": "#/definitions/handlers.ErrorResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "Não autenticado",
+                        "schema": {
+                            "$ref": "#/definitions/handlers.ErrorResponse"
+                        }
+                    },
+                    "403": {
+                        "description": "Acesso negado",
+                        "schema": {
+                            "$ref": "#/definitions/handlers.ErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Modelo ou marca não encontrado",
+                        "schema": {
+                            "$ref": "#/definitions/handlers.ErrorResponse"
+                        }
+                    },
+                    "409": {
+                        "description": "Conflito (nome duplicado ou veículo referenciando)",
+                        "schema": {
+                            "$ref": "#/definitions/handlers.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Erro interno",
+                        "schema": {
+                            "$ref": "#/definitions/handlers.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
         "/admin/notification-categories": {
             "post": {
                 "security": [
@@ -3962,7 +4502,7 @@
                         "BearerAuth": []
                     }
                 ],
-                "description": "Retorna veículos em que o CPF é proprietário ou condutor aceito, com role em cada item.",
+                "description": "Retorna veículos em que o CPF é proprietário ou condutor aceito, com role em cada item. Quando role=conductor, inclui conductor_id (id do vínculo aceito).",
                 "consumes": [
                     "application/json"
                 ],
@@ -4110,7 +4650,7 @@
                         "BearerAuth": []
                     }
                 ],
-                "description": "Retorna o detalhe do veículo para proprietário ou condutor aceito (inclui invoice_photo_url, metadados de arquivos e registration_number). owner_name/owner_phone/owner_email são enriquecidos ao vivo via RMI a partir de owner_cpf.",
+                "description": "Retorna o detalhe do veículo para proprietário ou condutor aceito (inclui invoice_photo_url, metadados de arquivos e registration_number). Quando role=conductor, inclui conductor_id (id do vínculo aceito). owner_name/owner_phone/owner_email são enriquecidos ao vivo via RMI a partir de owner_cpf.",
                 "consumes": [
                     "application/json"
                 ],
@@ -9373,6 +9913,9 @@
         "models.VehicleBrand": {
             "type": "object",
             "properties": {
+                "deleted_at": {
+                    "type": "string"
+                },
                 "id": {
                     "type": "string",
                     "example": "brand_caloi"
@@ -9381,6 +9924,30 @@
                     "type": "boolean",
                     "example": false
                 },
+                "name": {
+                    "type": "string",
+                    "example": "Caloi"
+                }
+            }
+        },
+        "models.VehicleBrandCreateRequest": {
+            "type": "object",
+            "required": [
+                "name"
+            ],
+            "properties": {
+                "name": {
+                    "type": "string",
+                    "example": "Caloi"
+                }
+            }
+        },
+        "models.VehicleBrandUpdateRequest": {
+            "type": "object",
+            "required": [
+                "name"
+            ],
+            "properties": {
                 "name": {
                     "type": "string",
                     "example": "Caloi"
@@ -9548,6 +10115,10 @@
                 "color": {
                     "type": "string"
                 },
+                "conductor_id": {
+                    "description": "ConductorID is the accepted VehicleConductor link id when Role is conductor (same id used in DELETE/PATCH paths).",
+                    "type": "string"
+                },
                 "created_at": {
                     "type": "string"
                 },
@@ -9704,6 +10275,10 @@
                 "color": {
                     "type": "string"
                 },
+                "conductor_id": {
+                    "description": "ConductorID is the accepted VehicleConductor link id when Role is conductor (same id used in DELETE/PATCH paths).",
+                    "type": "string"
+                },
                 "display_name": {
                     "type": "string"
                 },
@@ -9738,6 +10313,9 @@
                     "type": "string",
                     "example": "brand_caloi"
                 },
+                "deleted_at": {
+                    "type": "string"
+                },
                 "id": {
                     "type": "string",
                     "example": "model_e-vibe"
@@ -9749,6 +10327,46 @@
                 "name": {
                     "type": "string",
                     "example": "E-Vibe"
+                },
+                "vehicle_type": {
+                    "$ref": "#/definitions/models.VehicleType"
+                }
+            }
+        },
+        "models.VehicleModelCreateRequest": {
+            "type": "object",
+            "required": [
+                "brand_id",
+                "name",
+                "vehicle_type"
+            ],
+            "properties": {
+                "brand_id": {
+                    "type": "string",
+                    "example": "brand_caloi"
+                },
+                "name": {
+                    "type": "string",
+                    "example": "E-Vibe"
+                },
+                "vehicle_type": {
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/models.VehicleType"
+                        }
+                    ],
+                    "example": "bicicleta_eletrica"
+                }
+            }
+        },
+        "models.VehicleModelUpdateRequest": {
+            "type": "object",
+            "properties": {
+                "brand_id": {
+                    "type": "string"
+                },
+                "name": {
+                    "type": "string"
                 },
                 "vehicle_type": {
                     "$ref": "#/definitions/models.VehicleType"

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -1745,6 +1745,8 @@ definitions:
     type: object
   models.VehicleBrand:
     properties:
+      deleted_at:
+        type: string
       id:
         example: brand_caloi
         type: string
@@ -1754,6 +1756,22 @@ definitions:
       name:
         example: Caloi
         type: string
+    type: object
+  models.VehicleBrandCreateRequest:
+    properties:
+      name:
+        example: Caloi
+        type: string
+    required:
+    - name
+    type: object
+  models.VehicleBrandUpdateRequest:
+    properties:
+      name:
+        example: Caloi
+        type: string
+    required:
+    - name
     type: object
   models.VehicleBrandsResponse:
     properties:
@@ -1865,6 +1883,10 @@ definitions:
         type: string
       color:
         type: string
+      conductor_id:
+        description: ConductorID is the accepted VehicleConductor link id when Role
+          is conductor (same id used in DELETE/PATCH paths).
+        type: string
       created_at:
         type: string
       deleted_at:
@@ -1970,6 +1992,10 @@ definitions:
         type: string
       color:
         type: string
+      conductor_id:
+        description: ConductorID is the accepted VehicleConductor link id when Role
+          is conductor (same id used in DELETE/PATCH paths).
+        type: string
       display_name:
         type: string
       id:
@@ -1993,6 +2019,8 @@ definitions:
       brand_id:
         example: brand_caloi
         type: string
+      deleted_at:
+        type: string
       id:
         example: model_e-vibe
         type: string
@@ -2001,6 +2029,32 @@ definitions:
         type: boolean
       name:
         example: E-Vibe
+        type: string
+      vehicle_type:
+        $ref: '#/definitions/models.VehicleType'
+    type: object
+  models.VehicleModelCreateRequest:
+    properties:
+      brand_id:
+        example: brand_caloi
+        type: string
+      name:
+        example: E-Vibe
+        type: string
+      vehicle_type:
+        allOf:
+        - $ref: '#/definitions/models.VehicleType'
+        example: bicicleta_eletrica
+    required:
+    - brand_id
+    - name
+    - vehicle_type
+    type: object
+  models.VehicleModelUpdateRequest:
+    properties:
+      brand_id:
+        type: string
+      name:
         type: string
       vehicle_type:
         $ref: '#/definitions/models.VehicleType'
@@ -2785,6 +2839,360 @@ paths:
       tags:
       - admin
       - cpf-secretaria
+  /admin/mobilidade/vehicle-brands:
+    get:
+      consumes:
+      - application/json
+      description: Lista completa de marcas do catálogo, incluindo soft-deleted (admin).
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: Lista tipada de marcas em data
+          schema:
+            $ref: '#/definitions/models.VehicleBrandsResponse'
+        "401":
+          description: Não autenticado
+          schema:
+            $ref: '#/definitions/handlers.ErrorResponse'
+        "403":
+          description: Acesso negado
+          schema:
+            $ref: '#/definitions/handlers.ErrorResponse'
+        "500":
+          description: Erro interno
+          schema:
+            $ref: '#/definitions/handlers.ErrorResponse'
+      security:
+      - BearerAuth: []
+      summary: Listar marcas (admin)
+      tags:
+      - mobilidade
+    post:
+      consumes:
+      - application/json
+      description: Cadastra uma marca no catálogo. ID gerado no backend (brand_&lt;slug&gt;);
+        is_other=false.
+      parameters:
+      - description: Nome da marca
+        in: body
+        name: body
+        required: true
+        schema:
+          $ref: '#/definitions/models.VehicleBrandCreateRequest'
+      produces:
+      - application/json
+      responses:
+        "201":
+          description: Marca criada
+          schema:
+            $ref: '#/definitions/models.VehicleBrand'
+        "400":
+          description: Validação inválida
+          schema:
+            $ref: '#/definitions/handlers.ErrorResponse'
+        "401":
+          description: Não autenticado
+          schema:
+            $ref: '#/definitions/handlers.ErrorResponse'
+        "403":
+          description: Acesso negado
+          schema:
+            $ref: '#/definitions/handlers.ErrorResponse'
+        "409":
+          description: Nome ou ID já existente
+          schema:
+            $ref: '#/definitions/handlers.ErrorResponse'
+        "500":
+          description: Erro interno
+          schema:
+            $ref: '#/definitions/handlers.ErrorResponse'
+      security:
+      - BearerAuth: []
+      summary: Criar marca (admin)
+      tags:
+      - mobilidade
+  /admin/mobilidade/vehicle-brands/{brand_id}:
+    delete:
+      consumes:
+      - application/json
+      description: Soft-delete de marca. 409 se houver modelos ativos ou veículos
+        referenciando. Sentinel brand_outro não pode ser excluída.
+      parameters:
+      - description: ID da marca
+        in: path
+        name: brand_id
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "204":
+          description: Marca excluída
+        "400":
+          description: Sentinel ou validação
+          schema:
+            $ref: '#/definitions/handlers.ErrorResponse'
+        "401":
+          description: Não autenticado
+          schema:
+            $ref: '#/definitions/handlers.ErrorResponse'
+        "403":
+          description: Acesso negado
+          schema:
+            $ref: '#/definitions/handlers.ErrorResponse'
+        "404":
+          description: Marca não encontrada
+          schema:
+            $ref: '#/definitions/handlers.ErrorResponse'
+        "409":
+          description: Modelos ativos ou veículos referenciando
+          schema:
+            $ref: '#/definitions/handlers.ErrorResponse'
+        "500":
+          description: Erro interno
+          schema:
+            $ref: '#/definitions/handlers.ErrorResponse'
+      security:
+      - BearerAuth: []
+      summary: Excluir marca (admin, soft-delete)
+      tags:
+      - mobilidade
+    patch:
+      consumes:
+      - application/json
+      description: Atualiza o nome de uma marca ativa. Sentinel brand_outro não pode
+        ser alterada. 409 se referenciada por veículo.
+      parameters:
+      - description: ID da marca
+        in: path
+        name: brand_id
+        required: true
+        type: string
+      - description: Campos a atualizar
+        in: body
+        name: body
+        required: true
+        schema:
+          $ref: '#/definitions/models.VehicleBrandUpdateRequest'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: Marca atualizada
+          schema:
+            $ref: '#/definitions/models.VehicleBrand'
+        "400":
+          description: Validação inválida ou sentinel
+          schema:
+            $ref: '#/definitions/handlers.ErrorResponse'
+        "401":
+          description: Não autenticado
+          schema:
+            $ref: '#/definitions/handlers.ErrorResponse'
+        "403":
+          description: Acesso negado
+          schema:
+            $ref: '#/definitions/handlers.ErrorResponse'
+        "404":
+          description: Marca não encontrada
+          schema:
+            $ref: '#/definitions/handlers.ErrorResponse'
+        "409":
+          description: Conflito (nome duplicado ou veículo referenciando)
+          schema:
+            $ref: '#/definitions/handlers.ErrorResponse'
+        "500":
+          description: Erro interno
+          schema:
+            $ref: '#/definitions/handlers.ErrorResponse'
+      security:
+      - BearerAuth: []
+      summary: Atualizar marca (admin)
+      tags:
+      - mobilidade
+  /admin/mobilidade/vehicle-models:
+    get:
+      consumes:
+      - application/json
+      description: Lista completa de modelos, incluindo soft-deleted. Filtro opcional
+        por brand_id.
+      parameters:
+      - description: Filtrar por ID da marca
+        in: query
+        name: brand_id
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: Lista tipada de modelos em data
+          schema:
+            $ref: '#/definitions/models.VehicleModelsResponse'
+        "401":
+          description: Não autenticado
+          schema:
+            $ref: '#/definitions/handlers.ErrorResponse'
+        "403":
+          description: Acesso negado
+          schema:
+            $ref: '#/definitions/handlers.ErrorResponse'
+        "500":
+          description: Erro interno
+          schema:
+            $ref: '#/definitions/handlers.ErrorResponse'
+      security:
+      - BearerAuth: []
+      summary: Listar modelos (admin)
+      tags:
+      - mobilidade
+    post:
+      consumes:
+      - application/json
+      description: Cadastra um modelo vinculado a brand_id com vehicle_type. ID gerado
+        no backend; is_other=false.
+      parameters:
+      - description: Dados do modelo
+        in: body
+        name: body
+        required: true
+        schema:
+          $ref: '#/definitions/models.VehicleModelCreateRequest'
+      produces:
+      - application/json
+      responses:
+        "201":
+          description: Modelo criado
+          schema:
+            $ref: '#/definitions/models.VehicleModel'
+        "400":
+          description: Validação inválida
+          schema:
+            $ref: '#/definitions/handlers.ErrorResponse'
+        "401":
+          description: Não autenticado
+          schema:
+            $ref: '#/definitions/handlers.ErrorResponse'
+        "403":
+          description: Acesso negado
+          schema:
+            $ref: '#/definitions/handlers.ErrorResponse'
+        "404":
+          description: Marca não encontrada
+          schema:
+            $ref: '#/definitions/handlers.ErrorResponse'
+        "409":
+          description: Nome ou ID já existente
+          schema:
+            $ref: '#/definitions/handlers.ErrorResponse'
+        "500":
+          description: Erro interno
+          schema:
+            $ref: '#/definitions/handlers.ErrorResponse'
+      security:
+      - BearerAuth: []
+      summary: Criar modelo (admin)
+      tags:
+      - mobilidade
+  /admin/mobilidade/vehicle-models/{model_id}:
+    delete:
+      consumes:
+      - application/json
+      description: Soft-delete de modelo. 409 se veículos referenciarem. Sentinel
+        model_outro não pode ser excluído.
+      parameters:
+      - description: ID do modelo
+        in: path
+        name: model_id
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "204":
+          description: Modelo excluído
+        "400":
+          description: Sentinel ou validação
+          schema:
+            $ref: '#/definitions/handlers.ErrorResponse'
+        "401":
+          description: Não autenticado
+          schema:
+            $ref: '#/definitions/handlers.ErrorResponse'
+        "403":
+          description: Acesso negado
+          schema:
+            $ref: '#/definitions/handlers.ErrorResponse'
+        "404":
+          description: Modelo não encontrado
+          schema:
+            $ref: '#/definitions/handlers.ErrorResponse'
+        "409":
+          description: Veículos referenciando
+          schema:
+            $ref: '#/definitions/handlers.ErrorResponse'
+        "500":
+          description: Erro interno
+          schema:
+            $ref: '#/definitions/handlers.ErrorResponse'
+      security:
+      - BearerAuth: []
+      summary: Excluir modelo (admin, soft-delete)
+      tags:
+      - mobilidade
+    patch:
+      consumes:
+      - application/json
+      description: Atualiza nome, vehicle_type e/ou brand_id de um modelo ativo. Sentinel
+        model_outro não pode ser alterado. 409 se referenciado por veículo.
+      parameters:
+      - description: ID do modelo
+        in: path
+        name: model_id
+        required: true
+        type: string
+      - description: Campos a atualizar
+        in: body
+        name: body
+        required: true
+        schema:
+          $ref: '#/definitions/models.VehicleModelUpdateRequest'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: Modelo atualizado
+          schema:
+            $ref: '#/definitions/models.VehicleModel'
+        "400":
+          description: Validação inválida ou sentinel
+          schema:
+            $ref: '#/definitions/handlers.ErrorResponse'
+        "401":
+          description: Não autenticado
+          schema:
+            $ref: '#/definitions/handlers.ErrorResponse'
+        "403":
+          description: Acesso negado
+          schema:
+            $ref: '#/definitions/handlers.ErrorResponse'
+        "404":
+          description: Modelo ou marca não encontrado
+          schema:
+            $ref: '#/definitions/handlers.ErrorResponse'
+        "409":
+          description: Conflito (nome duplicado ou veículo referenciando)
+          schema:
+            $ref: '#/definitions/handlers.ErrorResponse'
+        "500":
+          description: Erro interno
+          schema:
+            $ref: '#/definitions/handlers.ErrorResponse'
+      security:
+      - BearerAuth: []
+      summary: Atualizar modelo (admin)
+      tags:
+      - mobilidade
   /admin/notification-categories:
     post:
       consumes:
@@ -4571,7 +4979,8 @@ paths:
       consumes:
       - application/json
       description: Retorna veículos em que o CPF é proprietário ou condutor aceito,
-        com role em cada item.
+        com role em cada item. Quando role=conductor, inclui conductor_id (id do vínculo
+        aceito).
       parameters:
       - description: CPF do cidadão (11 dígitos)
         in: path
@@ -4723,7 +5132,8 @@ paths:
       consumes:
       - application/json
       description: Retorna o detalhe do veículo para proprietário ou condutor aceito
-        (inclui invoice_photo_url, metadados de arquivos e registration_number). owner_name/owner_phone/owner_email
+        (inclui invoice_photo_url, metadados de arquivos e registration_number). Quando
+        role=conductor, inclui conductor_id (id do vínculo aceito). owner_name/owner_phone/owner_email
         são enriquecidos ao vivo via RMI a partir de owner_cpf.
       parameters:
       - description: CPF do cidadão (11 dígitos)

--- a/internal/handlers/mobilidade_catalog_admin.go
+++ b/internal/handlers/mobilidade_catalog_admin.go
@@ -1,0 +1,269 @@
+package handlers
+
+import (
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+	"github.com/prefeitura-rio/app-rmi/internal/models"
+	"github.com/prefeitura-rio/app-rmi/internal/services"
+)
+
+// AdminListMobilidadeVehicleBrands godoc
+// @Summary Listar marcas (admin)
+// @Description Lista completa de marcas do catálogo, incluindo soft-deleted (admin).
+// @Tags mobilidade
+// @Accept json
+// @Produce json
+// @Security BearerAuth
+// @Success 200 {object} models.VehicleBrandsResponse "Lista tipada de marcas em data"
+// @Failure 401 {object} ErrorResponse "Não autenticado"
+// @Failure 403 {object} ErrorResponse "Acesso negado"
+// @Failure 500 {object} ErrorResponse "Erro interno"
+// @Router /admin/mobilidade/vehicle-brands [get]
+func AdminListMobilidadeVehicleBrands(c *gin.Context) {
+	if services.MobilidadeCatalogServiceInstance == nil {
+		c.JSON(http.StatusInternalServerError, ErrorResponse{Error: "Catalog service unavailable"})
+		return
+	}
+	result, err := services.MobilidadeCatalogServiceInstance.ListBrandsAdmin(c.Request.Context())
+	if err != nil {
+		mapMobilidadeError(c, err)
+		return
+	}
+	c.JSON(http.StatusOK, models.VehicleBrandsResponse{Data: result})
+}
+
+// CreateMobilidadeVehicleBrand godoc
+// @Summary Criar marca (admin)
+// @Description Cadastra uma marca no catálogo. ID gerado no backend (brand_&lt;slug&gt;); is_other=false.
+// @Tags mobilidade
+// @Accept json
+// @Produce json
+// @Param body body models.VehicleBrandCreateRequest true "Nome da marca"
+// @Security BearerAuth
+// @Success 201 {object} models.VehicleBrand "Marca criada"
+// @Failure 400 {object} ErrorResponse "Validação inválida"
+// @Failure 401 {object} ErrorResponse "Não autenticado"
+// @Failure 403 {object} ErrorResponse "Acesso negado"
+// @Failure 409 {object} ErrorResponse "Nome ou ID já existente"
+// @Failure 500 {object} ErrorResponse "Erro interno"
+// @Router /admin/mobilidade/vehicle-brands [post]
+func CreateMobilidadeVehicleBrand(c *gin.Context) {
+	var req models.VehicleBrandCreateRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		c.JSON(http.StatusBadRequest, ErrorResponse{Error: "Invalid request: " + err.Error()})
+		return
+	}
+	if err := req.Validate(); err != nil {
+		c.JSON(http.StatusBadRequest, ErrorResponse{Error: err.Error()})
+		return
+	}
+	if services.MobilidadeCatalogServiceInstance == nil {
+		c.JSON(http.StatusInternalServerError, ErrorResponse{Error: "Catalog service unavailable"})
+		return
+	}
+	result, err := services.MobilidadeCatalogServiceInstance.CreateBrand(c.Request.Context(), &req)
+	if err != nil {
+		mapMobilidadeError(c, err)
+		return
+	}
+	c.JSON(http.StatusCreated, result)
+}
+
+// UpdateMobilidadeVehicleBrand godoc
+// @Summary Atualizar marca (admin)
+// @Description Atualiza o nome de uma marca ativa. Sentinel brand_outro não pode ser alterada. 409 se referenciada por veículo.
+// @Tags mobilidade
+// @Accept json
+// @Produce json
+// @Param brand_id path string true "ID da marca"
+// @Param body body models.VehicleBrandUpdateRequest true "Campos a atualizar"
+// @Security BearerAuth
+// @Success 200 {object} models.VehicleBrand "Marca atualizada"
+// @Failure 400 {object} ErrorResponse "Validação inválida ou sentinel"
+// @Failure 401 {object} ErrorResponse "Não autenticado"
+// @Failure 403 {object} ErrorResponse "Acesso negado"
+// @Failure 404 {object} ErrorResponse "Marca não encontrada"
+// @Failure 409 {object} ErrorResponse "Conflito (nome duplicado ou veículo referenciando)"
+// @Failure 500 {object} ErrorResponse "Erro interno"
+// @Router /admin/mobilidade/vehicle-brands/{brand_id} [patch]
+func UpdateMobilidadeVehicleBrand(c *gin.Context) {
+	var req models.VehicleBrandUpdateRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		c.JSON(http.StatusBadRequest, ErrorResponse{Error: "Invalid request: " + err.Error()})
+		return
+	}
+	if err := req.Validate(); err != nil {
+		c.JSON(http.StatusBadRequest, ErrorResponse{Error: err.Error()})
+		return
+	}
+	if services.MobilidadeCatalogServiceInstance == nil {
+		c.JSON(http.StatusInternalServerError, ErrorResponse{Error: "Catalog service unavailable"})
+		return
+	}
+	result, err := services.MobilidadeCatalogServiceInstance.UpdateBrand(c.Request.Context(), c.Param("brand_id"), &req)
+	if err != nil {
+		mapMobilidadeError(c, err)
+		return
+	}
+	c.JSON(http.StatusOK, result)
+}
+
+// DeleteMobilidadeVehicleBrand godoc
+// @Summary Excluir marca (admin, soft-delete)
+// @Description Soft-delete de marca. 409 se houver modelos ativos ou veículos referenciando. Sentinel brand_outro não pode ser excluída.
+// @Tags mobilidade
+// @Accept json
+// @Produce json
+// @Param brand_id path string true "ID da marca"
+// @Security BearerAuth
+// @Success 204 "Marca excluída"
+// @Failure 400 {object} ErrorResponse "Sentinel ou validação"
+// @Failure 401 {object} ErrorResponse "Não autenticado"
+// @Failure 403 {object} ErrorResponse "Acesso negado"
+// @Failure 404 {object} ErrorResponse "Marca não encontrada"
+// @Failure 409 {object} ErrorResponse "Modelos ativos ou veículos referenciando"
+// @Failure 500 {object} ErrorResponse "Erro interno"
+// @Router /admin/mobilidade/vehicle-brands/{brand_id} [delete]
+func DeleteMobilidadeVehicleBrand(c *gin.Context) {
+	if services.MobilidadeCatalogServiceInstance == nil {
+		c.JSON(http.StatusInternalServerError, ErrorResponse{Error: "Catalog service unavailable"})
+		return
+	}
+	if err := services.MobilidadeCatalogServiceInstance.DeleteBrand(c.Request.Context(), c.Param("brand_id")); err != nil {
+		mapMobilidadeError(c, err)
+		return
+	}
+	c.Status(http.StatusNoContent)
+}
+
+// AdminListMobilidadeVehicleModels godoc
+// @Summary Listar modelos (admin)
+// @Description Lista completa de modelos, incluindo soft-deleted. Filtro opcional por brand_id.
+// @Tags mobilidade
+// @Accept json
+// @Produce json
+// @Param brand_id query string false "Filtrar por ID da marca"
+// @Security BearerAuth
+// @Success 200 {object} models.VehicleModelsResponse "Lista tipada de modelos em data"
+// @Failure 401 {object} ErrorResponse "Não autenticado"
+// @Failure 403 {object} ErrorResponse "Acesso negado"
+// @Failure 500 {object} ErrorResponse "Erro interno"
+// @Router /admin/mobilidade/vehicle-models [get]
+func AdminListMobilidadeVehicleModels(c *gin.Context) {
+	if services.MobilidadeCatalogServiceInstance == nil {
+		c.JSON(http.StatusInternalServerError, ErrorResponse{Error: "Catalog service unavailable"})
+		return
+	}
+	result, err := services.MobilidadeCatalogServiceInstance.ListModelsAdmin(c.Request.Context(), c.Query("brand_id"))
+	if err != nil {
+		mapMobilidadeError(c, err)
+		return
+	}
+	c.JSON(http.StatusOK, models.VehicleModelsResponse{Data: result})
+}
+
+// CreateMobilidadeVehicleModel godoc
+// @Summary Criar modelo (admin)
+// @Description Cadastra um modelo vinculado a brand_id com vehicle_type. ID gerado no backend; is_other=false.
+// @Tags mobilidade
+// @Accept json
+// @Produce json
+// @Param body body models.VehicleModelCreateRequest true "Dados do modelo"
+// @Security BearerAuth
+// @Success 201 {object} models.VehicleModel "Modelo criado"
+// @Failure 400 {object} ErrorResponse "Validação inválida"
+// @Failure 401 {object} ErrorResponse "Não autenticado"
+// @Failure 403 {object} ErrorResponse "Acesso negado"
+// @Failure 404 {object} ErrorResponse "Marca não encontrada"
+// @Failure 409 {object} ErrorResponse "Nome ou ID já existente"
+// @Failure 500 {object} ErrorResponse "Erro interno"
+// @Router /admin/mobilidade/vehicle-models [post]
+func CreateMobilidadeVehicleModel(c *gin.Context) {
+	var req models.VehicleModelCreateRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		c.JSON(http.StatusBadRequest, ErrorResponse{Error: "Invalid request: " + err.Error()})
+		return
+	}
+	if err := req.Validate(); err != nil {
+		c.JSON(http.StatusBadRequest, ErrorResponse{Error: err.Error()})
+		return
+	}
+	if services.MobilidadeCatalogServiceInstance == nil {
+		c.JSON(http.StatusInternalServerError, ErrorResponse{Error: "Catalog service unavailable"})
+		return
+	}
+	result, err := services.MobilidadeCatalogServiceInstance.CreateModel(c.Request.Context(), &req)
+	if err != nil {
+		mapMobilidadeError(c, err)
+		return
+	}
+	c.JSON(http.StatusCreated, result)
+}
+
+// UpdateMobilidadeVehicleModel godoc
+// @Summary Atualizar modelo (admin)
+// @Description Atualiza nome, vehicle_type e/ou brand_id de um modelo ativo. Sentinel model_outro não pode ser alterado. 409 se referenciado por veículo.
+// @Tags mobilidade
+// @Accept json
+// @Produce json
+// @Param model_id path string true "ID do modelo"
+// @Param body body models.VehicleModelUpdateRequest true "Campos a atualizar"
+// @Security BearerAuth
+// @Success 200 {object} models.VehicleModel "Modelo atualizado"
+// @Failure 400 {object} ErrorResponse "Validação inválida ou sentinel"
+// @Failure 401 {object} ErrorResponse "Não autenticado"
+// @Failure 403 {object} ErrorResponse "Acesso negado"
+// @Failure 404 {object} ErrorResponse "Modelo ou marca não encontrado"
+// @Failure 409 {object} ErrorResponse "Conflito (nome duplicado ou veículo referenciando)"
+// @Failure 500 {object} ErrorResponse "Erro interno"
+// @Router /admin/mobilidade/vehicle-models/{model_id} [patch]
+func UpdateMobilidadeVehicleModel(c *gin.Context) {
+	var req models.VehicleModelUpdateRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		c.JSON(http.StatusBadRequest, ErrorResponse{Error: "Invalid request: " + err.Error()})
+		return
+	}
+	if err := req.Validate(); err != nil {
+		c.JSON(http.StatusBadRequest, ErrorResponse{Error: err.Error()})
+		return
+	}
+	if services.MobilidadeCatalogServiceInstance == nil {
+		c.JSON(http.StatusInternalServerError, ErrorResponse{Error: "Catalog service unavailable"})
+		return
+	}
+	result, err := services.MobilidadeCatalogServiceInstance.UpdateModel(c.Request.Context(), c.Param("model_id"), &req)
+	if err != nil {
+		mapMobilidadeError(c, err)
+		return
+	}
+	c.JSON(http.StatusOK, result)
+}
+
+// DeleteMobilidadeVehicleModel godoc
+// @Summary Excluir modelo (admin, soft-delete)
+// @Description Soft-delete de modelo. 409 se veículos referenciarem. Sentinel model_outro não pode ser excluído.
+// @Tags mobilidade
+// @Accept json
+// @Produce json
+// @Param model_id path string true "ID do modelo"
+// @Security BearerAuth
+// @Success 204 "Modelo excluído"
+// @Failure 400 {object} ErrorResponse "Sentinel ou validação"
+// @Failure 401 {object} ErrorResponse "Não autenticado"
+// @Failure 403 {object} ErrorResponse "Acesso negado"
+// @Failure 404 {object} ErrorResponse "Modelo não encontrado"
+// @Failure 409 {object} ErrorResponse "Veículos referenciando"
+// @Failure 500 {object} ErrorResponse "Erro interno"
+// @Router /admin/mobilidade/vehicle-models/{model_id} [delete]
+func DeleteMobilidadeVehicleModel(c *gin.Context) {
+	if services.MobilidadeCatalogServiceInstance == nil {
+		c.JSON(http.StatusInternalServerError, ErrorResponse{Error: "Catalog service unavailable"})
+		return
+	}
+	if err := services.MobilidadeCatalogServiceInstance.DeleteModel(c.Request.Context(), c.Param("model_id")); err != nil {
+		mapMobilidadeError(c, err)
+		return
+	}
+	c.Status(http.StatusNoContent)
+}

--- a/internal/handlers/mobilidade_catalog_admin_test.go
+++ b/internal/handlers/mobilidade_catalog_admin_test.go
@@ -1,0 +1,357 @@
+package handlers
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/prefeitura-rio/app-rmi/internal/config"
+	"github.com/prefeitura-rio/app-rmi/internal/logging"
+	"github.com/prefeitura-rio/app-rmi/internal/models"
+	"github.com/prefeitura-rio/app-rmi/internal/services"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.mongodb.org/mongo-driver/bson"
+)
+
+func setupMobilidadeCatalogAdminHandlersTest(t *testing.T) (*gin.Engine, func()) {
+	t.Helper()
+	gin.SetMode(gin.TestMode)
+
+	config.AppConfig.MobilidadeBrandCollection = "test_mobilidade_admin_handlers_brands"
+	config.AppConfig.MobilidadeModelCollection = "test_mobilidade_admin_handlers_models"
+	config.AppConfig.MobilidadeVehicleCollection = "test_mobilidade_admin_handlers_vehicles"
+
+	ctx := context.Background()
+	db := config.MongoDB
+	require.NotNil(t, db)
+
+	services.MobilidadeCatalogServiceInstance = services.NewMobilidadeCatalogService(db, logging.GetLogger())
+	services.VehicleServiceInstance = services.NewVehicleService(db, services.NewDataManager(config.Redis, db, logging.GetLogger()), logging.GetLogger())
+
+	router := gin.New()
+	router.GET("/mobilidade/vehicle-brands", GetMobilidadeVehicleBrands)
+	router.GET("/mobilidade/vehicle-models", GetMobilidadeVehicleModels)
+	router.GET("/admin/mobilidade/vehicle-brands", AdminListMobilidadeVehicleBrands)
+	router.POST("/admin/mobilidade/vehicle-brands", CreateMobilidadeVehicleBrand)
+	router.PATCH("/admin/mobilidade/vehicle-brands/:brand_id", UpdateMobilidadeVehicleBrand)
+	router.DELETE("/admin/mobilidade/vehicle-brands/:brand_id", DeleteMobilidadeVehicleBrand)
+	router.GET("/admin/mobilidade/vehicle-models", AdminListMobilidadeVehicleModels)
+	router.POST("/admin/mobilidade/vehicle-models", CreateMobilidadeVehicleModel)
+	router.PATCH("/admin/mobilidade/vehicle-models/:model_id", UpdateMobilidadeVehicleModel)
+	router.DELETE("/admin/mobilidade/vehicle-models/:model_id", DeleteMobilidadeVehicleModel)
+
+	cleanupDB := func() {
+		_ = db.Collection(config.AppConfig.MobilidadeBrandCollection).Drop(ctx)
+		_ = db.Collection(config.AppConfig.MobilidadeModelCollection).Drop(ctx)
+		_ = db.Collection(config.AppConfig.MobilidadeVehicleCollection).Drop(ctx)
+	}
+	cleanupDB()
+	seedAdminHandlerCatalog(t)
+
+	cleanup := func() {
+		cleanupDB()
+		services.MobilidadeCatalogServiceInstance = nil
+		services.VehicleServiceInstance = nil
+	}
+	return router, cleanup
+}
+
+func seedAdminHandlerCatalog(t *testing.T) {
+	t.Helper()
+	ctx := context.Background()
+	_, err := config.MongoDB.Collection(config.AppConfig.MobilidadeBrandCollection).InsertMany(ctx, []interface{}{
+		bson.M{"_id": "brand_caloi", "name": "Caloi", "is_other": false},
+		bson.M{"_id": models.VehicleBrandOutroID, "name": "Outro", "is_other": true},
+	})
+	require.NoError(t, err)
+	_, err = config.MongoDB.Collection(config.AppConfig.MobilidadeModelCollection).InsertMany(ctx, []interface{}{
+		bson.M{
+			"_id": "model_e-vibe", "brand_id": "brand_caloi", "name": "E-Vibe",
+			"vehicle_type": "bicicleta_eletrica", "is_other": false,
+		},
+		bson.M{
+			"_id": models.VehicleModelOutroID, "brand_id": models.VehicleBrandOutroID, "name": "Outro",
+			"vehicle_type": "autopropelido", "is_other": true,
+		},
+	})
+	require.NoError(t, err)
+}
+
+func TestAdminMobilidadeCatalog_CreateBrand_Model_HTTP(t *testing.T) {
+	router, cleanup := setupMobilidadeCatalogAdminHandlersTest(t)
+	defer cleanup()
+
+	createBrandBody, _ := json.Marshal(models.VehicleBrandCreateRequest{Name: "Monark"})
+	req := httptest.NewRequest(http.MethodPost, "/admin/mobilidade/vehicle-brands", bytes.NewReader(createBrandBody))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+	require.Equal(t, http.StatusCreated, w.Code, w.Body.String())
+
+	var brand models.VehicleBrand
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &brand))
+	assert.Equal(t, "brand_monark", brand.ID)
+
+	createModelBody, _ := json.Marshal(models.VehicleModelCreateRequest{
+		BrandID: brand.ID, Name: "City", VehicleType: models.VehicleTypeAutopropelido,
+	})
+	req2 := httptest.NewRequest(http.MethodPost, "/admin/mobilidade/vehicle-models", bytes.NewReader(createModelBody))
+	req2.Header.Set("Content-Type", "application/json")
+	w2 := httptest.NewRecorder()
+	router.ServeHTTP(w2, req2)
+	require.Equal(t, http.StatusCreated, w2.Code, w2.Body.String())
+
+	publicReq := httptest.NewRequest(http.MethodGet, "/mobilidade/vehicle-brands", nil)
+	publicW := httptest.NewRecorder()
+	router.ServeHTTP(publicW, publicReq)
+	require.Equal(t, http.StatusOK, publicW.Code)
+	var public models.VehicleBrandsResponse
+	require.NoError(t, json.Unmarshal(publicW.Body.Bytes(), &public))
+	found := false
+	for _, b := range public.Data {
+		if b.ID == brand.ID {
+			found = true
+		}
+	}
+	assert.True(t, found)
+}
+
+func TestAdminMobilidadeCatalog_DeleteSentinel_HTTP(t *testing.T) {
+	router, cleanup := setupMobilidadeCatalogAdminHandlersTest(t)
+	defer cleanup()
+
+	req := httptest.NewRequest(http.MethodDelete, "/admin/mobilidade/vehicle-brands/"+models.VehicleBrandOutroID, nil)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+
+	req2 := httptest.NewRequest(http.MethodDelete, "/admin/mobilidade/vehicle-models/"+models.VehicleModelOutroID, nil)
+	w2 := httptest.NewRecorder()
+	router.ServeHTTP(w2, req2)
+	assert.Equal(t, http.StatusBadRequest, w2.Code)
+}
+
+func TestAdminMobilidadeCatalog_DuplicateBrand_HTTP(t *testing.T) {
+	router, cleanup := setupMobilidadeCatalogAdminHandlersTest(t)
+	defer cleanup()
+
+	body, _ := json.Marshal(models.VehicleBrandCreateRequest{Name: "Caloi"})
+	req := httptest.NewRequest(http.MethodPost, "/admin/mobilidade/vehicle-brands", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+	assert.Equal(t, http.StatusConflict, w.Code)
+}
+
+func TestAdminMobilidadeCatalog_InvalidBodies_HTTP(t *testing.T) {
+	router, cleanup := setupMobilidadeCatalogAdminHandlersTest(t)
+	defer cleanup()
+
+	req := httptest.NewRequest(http.MethodPost, "/admin/mobilidade/vehicle-brands", bytes.NewReader([]byte(`{not-json`)))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+
+	emptyName, _ := json.Marshal(map[string]string{"name": ""})
+	req2 := httptest.NewRequest(http.MethodPost, "/admin/mobilidade/vehicle-brands", bytes.NewReader(emptyName))
+	req2.Header.Set("Content-Type", "application/json")
+	w2 := httptest.NewRecorder()
+	router.ServeHTTP(w2, req2)
+	assert.Equal(t, http.StatusBadRequest, w2.Code)
+
+	badType, _ := json.Marshal(models.VehicleModelCreateRequest{
+		BrandID: "brand_caloi", Name: "X", VehicleType: models.VehicleType("nope"),
+	})
+	req3 := httptest.NewRequest(http.MethodPost, "/admin/mobilidade/vehicle-models", bytes.NewReader(badType))
+	req3.Header.Set("Content-Type", "application/json")
+	w3 := httptest.NewRecorder()
+	router.ServeHTTP(w3, req3)
+	assert.Equal(t, http.StatusBadRequest, w3.Code)
+}
+
+func TestAdminMobilidadeCatalog_NotFound_HTTP(t *testing.T) {
+	router, cleanup := setupMobilidadeCatalogAdminHandlersTest(t)
+	defer cleanup()
+
+	body, _ := json.Marshal(models.VehicleBrandUpdateRequest{Name: "X"})
+	req := httptest.NewRequest(http.MethodPatch, "/admin/mobilidade/vehicle-brands/brand_missing", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+	assert.Equal(t, http.StatusNotFound, w.Code)
+
+	del := httptest.NewRequest(http.MethodDelete, "/admin/mobilidade/vehicle-brands/brand_missing", nil)
+	delW := httptest.NewRecorder()
+	router.ServeHTTP(delW, del)
+	assert.Equal(t, http.StatusNotFound, delW.Code)
+
+	modelBody, _ := json.Marshal(map[string]string{"name": "X"})
+	req2 := httptest.NewRequest(http.MethodPatch, "/admin/mobilidade/vehicle-models/model_missing", bytes.NewReader(modelBody))
+	req2.Header.Set("Content-Type", "application/json")
+	w2 := httptest.NewRecorder()
+	router.ServeHTTP(w2, req2)
+	assert.Equal(t, http.StatusNotFound, w2.Code)
+
+	del2 := httptest.NewRequest(http.MethodDelete, "/admin/mobilidade/vehicle-models/model_missing", nil)
+	delW2 := httptest.NewRecorder()
+	router.ServeHTTP(delW2, del2)
+	assert.Equal(t, http.StatusNotFound, delW2.Code)
+
+	createOnMissingBrand, _ := json.Marshal(models.VehicleModelCreateRequest{
+		BrandID: "brand_missing", Name: "X", VehicleType: models.VehicleTypeCiclomotor,
+	})
+	req3 := httptest.NewRequest(http.MethodPost, "/admin/mobilidade/vehicle-models", bytes.NewReader(createOnMissingBrand))
+	req3.Header.Set("Content-Type", "application/json")
+	w3 := httptest.NewRecorder()
+	router.ServeHTTP(w3, req3)
+	assert.Equal(t, http.StatusNotFound, w3.Code)
+}
+
+func TestAdminMobilidadeCatalog_DeleteBrandWithModels_HTTP(t *testing.T) {
+	router, cleanup := setupMobilidadeCatalogAdminHandlersTest(t)
+	defer cleanup()
+
+	req := httptest.NewRequest(http.MethodDelete, "/admin/mobilidade/vehicle-brands/brand_caloi", nil)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+	assert.Equal(t, http.StatusConflict, w.Code)
+}
+
+func TestAdminMobilidadeCatalog_PatchDeleteModelAndSoftDeleteVisibility_HTTP(t *testing.T) {
+	router, cleanup := setupMobilidadeCatalogAdminHandlersTest(t)
+	defer cleanup()
+
+	createBrand, _ := json.Marshal(models.VehicleBrandCreateRequest{Name: "Oggi"})
+	req := httptest.NewRequest(http.MethodPost, "/admin/mobilidade/vehicle-brands", bytes.NewReader(createBrand))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+	require.Equal(t, http.StatusCreated, w.Code)
+	var brand models.VehicleBrand
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &brand))
+
+	patchBrand, _ := json.Marshal(models.VehicleBrandUpdateRequest{Name: "Oggi Bikes"})
+	patchReq := httptest.NewRequest(http.MethodPatch, "/admin/mobilidade/vehicle-brands/"+brand.ID, bytes.NewReader(patchBrand))
+	patchReq.Header.Set("Content-Type", "application/json")
+	patchW := httptest.NewRecorder()
+	router.ServeHTTP(patchW, patchReq)
+	require.Equal(t, http.StatusOK, patchW.Code, patchW.Body.String())
+
+	createModel, _ := json.Marshal(models.VehicleModelCreateRequest{
+		BrandID: brand.ID, Name: "Hacker", VehicleType: models.VehicleTypeBicicletaEletrica,
+	})
+	modelReq := httptest.NewRequest(http.MethodPost, "/admin/mobilidade/vehicle-models", bytes.NewReader(createModel))
+	modelReq.Header.Set("Content-Type", "application/json")
+	modelW := httptest.NewRecorder()
+	router.ServeHTTP(modelW, modelReq)
+	require.Equal(t, http.StatusCreated, modelW.Code, modelW.Body.String())
+	var model models.VehicleModel
+	require.NoError(t, json.Unmarshal(modelW.Body.Bytes(), &model))
+
+	patchModel, _ := json.Marshal(map[string]interface{}{
+		"name":         "Hacker Pro",
+		"vehicle_type": string(models.VehicleTypeCiclomotor),
+	})
+	pmReq := httptest.NewRequest(http.MethodPatch, "/admin/mobilidade/vehicle-models/"+model.ID, bytes.NewReader(patchModel))
+	pmReq.Header.Set("Content-Type", "application/json")
+	pmW := httptest.NewRecorder()
+	router.ServeHTTP(pmW, pmReq)
+	require.Equal(t, http.StatusOK, pmW.Code, pmW.Body.String())
+
+	delModel := httptest.NewRequest(http.MethodDelete, "/admin/mobilidade/vehicle-models/"+model.ID, nil)
+	delModelW := httptest.NewRecorder()
+	router.ServeHTTP(delModelW, delModel)
+	require.Equal(t, http.StatusNoContent, delModelW.Code)
+
+	publicModels := httptest.NewRequest(http.MethodGet, "/mobilidade/vehicle-models?brand_id="+brand.ID, nil)
+	publicMW := httptest.NewRecorder()
+	router.ServeHTTP(publicMW, publicModels)
+	require.Equal(t, http.StatusOK, publicMW.Code)
+	var modelsResp models.VehicleModelsResponse
+	require.NoError(t, json.Unmarshal(publicMW.Body.Bytes(), &modelsResp))
+	assert.Empty(t, modelsResp.Data)
+
+	adminModels := httptest.NewRequest(http.MethodGet, "/admin/mobilidade/vehicle-models?brand_id="+brand.ID, nil)
+	adminMW := httptest.NewRecorder()
+	router.ServeHTTP(adminMW, adminModels)
+	require.Equal(t, http.StatusOK, adminMW.Code)
+	var adminResp models.VehicleModelsResponse
+	require.NoError(t, json.Unmarshal(adminMW.Body.Bytes(), &adminResp))
+	require.Len(t, adminResp.Data, 1)
+	assert.NotNil(t, adminResp.Data[0].DeletedAt)
+
+	delBrand := httptest.NewRequest(http.MethodDelete, "/admin/mobilidade/vehicle-brands/"+brand.ID, nil)
+	delBrandW := httptest.NewRecorder()
+	router.ServeHTTP(delBrandW, delBrand)
+	require.Equal(t, http.StatusNoContent, delBrandW.Code)
+
+	publicBrands := httptest.NewRequest(http.MethodGet, "/mobilidade/vehicle-brands", nil)
+	publicBW := httptest.NewRecorder()
+	router.ServeHTTP(publicBW, publicBrands)
+	require.Equal(t, http.StatusOK, publicBW.Code)
+	var brandsResp models.VehicleBrandsResponse
+	require.NoError(t, json.Unmarshal(publicBW.Body.Bytes(), &brandsResp))
+	for _, b := range brandsResp.Data {
+		assert.NotEqual(t, brand.ID, b.ID)
+	}
+}
+
+func TestAdminMobilidadeCatalog_ConflictWhenReferencedByVehicle_HTTP(t *testing.T) {
+	router, cleanup := setupMobilidadeCatalogAdminHandlersTest(t)
+	defer cleanup()
+
+	seedHandlerCitizen(t, handlerOwnerCPF, "Ana Owner")
+
+	falseVal := false
+	created, err := services.VehicleServiceInstance.CreateVehicle(context.Background(), handlerOwnerCPF, &models.VehicleCreateRequest{
+		DisplayName: "Bike", BrandID: strPtr("brand_caloi"), ModelID: strPtr("model_e-vibe"),
+		Color: "Preto", SerialNumber: "SN", SerialNumberPhotoURL: "https://storage.googleapis.com/s.jpg",
+		VehiclePhotoURL: "https://storage.googleapis.com/v.jpg", HasInvoice: &falseVal, SelfDeclaration: true,
+	})
+	require.NoError(t, err)
+	require.NotNil(t, created.ModelID)
+
+	patchBrand, _ := json.Marshal(models.VehicleBrandUpdateRequest{Name: "Caloi Nova"})
+	req := httptest.NewRequest(http.MethodPatch, "/admin/mobilidade/vehicle-brands/brand_caloi", bytes.NewReader(patchBrand))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+	assert.Equal(t, http.StatusConflict, w.Code)
+
+	delBrand := httptest.NewRequest(http.MethodDelete, "/admin/mobilidade/vehicle-brands/brand_caloi", nil)
+	delBW := httptest.NewRecorder()
+	router.ServeHTTP(delBW, delBrand)
+	assert.Equal(t, http.StatusConflict, delBW.Code)
+
+	patchModel, _ := json.Marshal(map[string]string{"name": "E-Vibe Pro"})
+	pmReq := httptest.NewRequest(http.MethodPatch, "/admin/mobilidade/vehicle-models/model_e-vibe", bytes.NewReader(patchModel))
+	pmReq.Header.Set("Content-Type", "application/json")
+	pmW := httptest.NewRecorder()
+	router.ServeHTTP(pmW, pmReq)
+	assert.Equal(t, http.StatusConflict, pmW.Code)
+
+	delModel := httptest.NewRequest(http.MethodDelete, "/admin/mobilidade/vehicle-models/model_e-vibe", nil)
+	delMW := httptest.NewRecorder()
+	router.ServeHTTP(delMW, delModel)
+	assert.Equal(t, http.StatusConflict, delMW.Code)
+}
+
+func TestAdminMobilidadeCatalog_CreateModelOnSentinelBrand_HTTP(t *testing.T) {
+	router, cleanup := setupMobilidadeCatalogAdminHandlersTest(t)
+	defer cleanup()
+
+	body, _ := json.Marshal(models.VehicleModelCreateRequest{
+		BrandID: models.VehicleBrandOutroID, Name: "X", VehicleType: models.VehicleTypeAutopropelido,
+	})
+	req := httptest.NewRequest(http.MethodPost, "/admin/mobilidade/vehicle-models", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+}

--- a/internal/handlers/vehicle.go
+++ b/internal/handlers/vehicle.go
@@ -14,7 +14,7 @@ import (
 
 // GetVehicles godoc
 // @Summary Listar veículos da carteira (mobilidade)
-// @Description Retorna veículos em que o CPF é proprietário ou condutor aceito, com role em cada item.
+// @Description Retorna veículos em que o CPF é proprietário ou condutor aceito, com role em cada item. Quando role=conductor, inclui conductor_id (id do vínculo aceito).
 // @Tags mobilidade
 // @Accept json
 // @Produce json
@@ -56,7 +56,7 @@ func GetVehicles(c *gin.Context) {
 
 // GetVehicle godoc
 // @Summary Obter detalhe do veículo
-// @Description Retorna o detalhe do veículo para proprietário ou condutor aceito (inclui invoice_photo_url, metadados de arquivos e registration_number). owner_name/owner_phone/owner_email são enriquecidos ao vivo via RMI a partir de owner_cpf.
+// @Description Retorna o detalhe do veículo para proprietário ou condutor aceito (inclui invoice_photo_url, metadados de arquivos e registration_number). Quando role=conductor, inclui conductor_id (id do vínculo aceito). owner_name/owner_phone/owner_email são enriquecidos ao vivo via RMI a partir de owner_cpf.
 // @Tags mobilidade
 // @Accept json
 // @Produce json
@@ -413,6 +413,8 @@ func RemoveVehicleConductor(c *gin.Context) {
 func mapMobilidadeError(c *gin.Context, err error) {
 	switch {
 	case errors.Is(err, services.ErrVehicleNotFound), errors.Is(err, services.ErrConductorNotFound):
+		c.JSON(http.StatusNotFound, ErrorResponse{Error: err.Error()})
+	case errors.Is(err, services.ErrCatalogBrandNotFound), errors.Is(err, services.ErrCatalogModelNotFound):
 		c.JSON(http.StatusNotFound, ErrorResponse{Error: err.Error()})
 	case errors.Is(err, services.ErrMobilidadeForbidden):
 		c.JSON(http.StatusForbidden, ErrorResponse{Error: err.Error()})

--- a/internal/handlers/vehicle_test.go
+++ b/internal/handlers/vehicle_test.go
@@ -314,6 +314,26 @@ func TestConductorInviteAcceptFlow_HTTP(t *testing.T) {
 	require.NoError(t, json.Unmarshal(listW.Body.Bytes(), &list))
 	require.Equal(t, 1, list.Pagination.Total)
 	assert.Equal(t, models.VehicleRoleConductor, list.Data[0].Role)
+	assert.Equal(t, link.ID.Hex(), list.Data[0].ConductorID)
+
+	detailReq := httptest.NewRequest(http.MethodGet, "/citizen/"+handlerConductorCPF+"/vehicles/"+vehicle.ID.Hex(), nil)
+	detailW := httptest.NewRecorder()
+	router.ServeHTTP(detailW, detailReq)
+	require.Equal(t, http.StatusOK, detailW.Code, "body: %s", detailW.Body.String())
+	var detail models.VehicleDetail
+	require.NoError(t, json.Unmarshal(detailW.Body.Bytes(), &detail))
+	assert.Equal(t, models.VehicleRoleConductor, detail.Role)
+	assert.Equal(t, link.ID.Hex(), detail.ConductorID)
+
+	ownerListReq := httptest.NewRequest(http.MethodGet, "/citizen/"+handlerOwnerCPF+"/vehicles?page=1&per_page=10", nil)
+	ownerListW := httptest.NewRecorder()
+	router.ServeHTTP(ownerListW, ownerListReq)
+	require.Equal(t, http.StatusOK, ownerListW.Code)
+	var ownerList models.PaginatedVehicles
+	require.NoError(t, json.Unmarshal(ownerListW.Body.Bytes(), &ownerList))
+	require.Equal(t, 1, ownerList.Pagination.Total)
+	assert.Equal(t, models.VehicleRoleOwner, ownerList.Data[0].Role)
+	assert.Empty(t, ownerList.Data[0].ConductorID)
 }
 
 func TestInviteVehicleConductor_DuplicateReturnsConflict(t *testing.T) {
@@ -467,6 +487,29 @@ func TestGetAndRemoveVehicleConductors_HTTP(t *testing.T) {
 	require.NoError(t, json.Unmarshal(listW.Body.Bytes(), &list))
 	require.Len(t, list.Data, 1)
 	assert.Equal(t, link.ID.Hex(), list.Data[0].ID.Hex())
+	assert.Equal(t, models.ConductorStatusPending, list.Data[0].Status)
+	assert.Equal(t, "Condutor", list.Data[0].ConductorName)
+	assert.Equal(t, "condutor@example.com", list.Data[0].NotifyEmail)
+
+	patchBody, _ := json.Marshal(models.RespondInvitationRequest{Status: models.InvitationResponseAccepted})
+	patchReq := httptest.NewRequest(http.MethodPatch, "/citizen/"+handlerConductorCPF+"/vehicle-invitations/"+link.ID.Hex(), bytes.NewReader(patchBody))
+	patchReq.Header.Set("Content-Type", "application/json")
+	patchW := httptest.NewRecorder()
+	router.ServeHTTP(patchW, patchReq)
+	require.Equal(t, http.StatusOK, patchW.Code, "body: %s", patchW.Body.String())
+
+	listReqAccepted := httptest.NewRequest(http.MethodGet, "/citizen/"+handlerOwnerCPF+"/vehicles/"+created.ID.Hex()+"/conductors", nil)
+	listWAccepted := httptest.NewRecorder()
+	router.ServeHTTP(listWAccepted, listReqAccepted)
+	require.Equal(t, http.StatusOK, listWAccepted.Code, "body: %s", listWAccepted.Body.String())
+	var listAccepted models.ConductorsListResponse
+	require.NoError(t, json.Unmarshal(listWAccepted.Body.Bytes(), &listAccepted))
+	require.Len(t, listAccepted.Data, 1)
+	assert.Equal(t, models.ConductorStatusAccepted, listAccepted.Data[0].Status)
+	assert.Equal(t, "João Condutor", listAccepted.Data[0].ConductorName)
+	assert.Equal(t, "joao@example.com", listAccepted.Data[0].NotifyEmail)
+	assert.NotEqual(t, "Condutor", listAccepted.Data[0].ConductorName)
+	assert.NotEqual(t, "condutor@example.com", listAccepted.Data[0].NotifyEmail)
 
 	delReq := httptest.NewRequest(http.MethodDelete, "/citizen/"+handlerOwnerCPF+"/vehicles/"+created.ID.Hex()+"/conductors/"+link.ID.Hex(), nil)
 	delW := httptest.NewRecorder()
@@ -491,6 +534,8 @@ func TestMapMobilidadeError_Branches(t *testing.T) {
 	}{
 		{"not_found", services.ErrVehicleNotFound, http.StatusNotFound},
 		{"conductor_not_found", services.ErrConductorNotFound, http.StatusNotFound},
+		{"brand_not_found", services.ErrCatalogBrandNotFound, http.StatusNotFound},
+		{"model_not_found", services.ErrCatalogModelNotFound, http.StatusNotFound},
 		{"forbidden", services.ErrMobilidadeForbidden, http.StatusForbidden},
 		{"conflict", services.ErrMobilidadeConflict, http.StatusConflict},
 		{"invalid", services.ErrMobilidadeInvalidInput, http.StatusBadRequest},

--- a/internal/middleware/audit.go
+++ b/internal/middleware/audit.go
@@ -185,6 +185,8 @@ func extractResourceFromPath(path string) string {
 			return utils.AuditResourceBetaWhitelist
 		case strings.HasPrefix(path, "admin/notification-categories") || strings.HasPrefix(path, "notification-categories"):
 			return utils.AuditResourceNotificationCategory
+		case strings.HasPrefix(path, "admin/mobilidade/"):
+			return "mobilidade_catalog"
 		default:
 			return resource
 		}
@@ -209,6 +211,12 @@ func extractResourceID(c *gin.Context, path string) string {
 		return id
 	}
 	if id := c.Param("category_id"); id != "" {
+		return id
+	}
+	if id := c.Param("brand_id"); id != "" {
+		return id
+	}
+	if id := c.Param("model_id"); id != "" {
 		return id
 	}
 	if id := c.Param("pet_id"); id != "" {

--- a/internal/models/vehicle.go
+++ b/internal/models/vehicle.go
@@ -105,9 +105,10 @@ const (
 
 // VehicleBrand is a seeded catalog brand (Marca).
 type VehicleBrand struct {
-	ID      string `bson:"_id" json:"id" example:"brand_caloi"`
-	Name    string `bson:"name" json:"name" example:"Caloi"`
-	IsOther bool   `bson:"is_other" json:"is_other" example:"false"`
+	ID        string     `bson:"_id" json:"id" example:"brand_caloi"`
+	Name      string     `bson:"name" json:"name" example:"Caloi"`
+	IsOther   bool       `bson:"is_other" json:"is_other" example:"false"`
+	DeletedAt *time.Time `bson:"deleted_at,omitempty" json:"deleted_at,omitempty"`
 }
 
 // VehicleModel is a seeded catalog model belonging to a brand.
@@ -117,6 +118,7 @@ type VehicleModel struct {
 	Name        string      `bson:"name" json:"name" example:"E-Vibe"`
 	VehicleType VehicleType `bson:"vehicle_type" json:"vehicle_type"`
 	IsOther     bool        `bson:"is_other" json:"is_other" example:"false"`
+	DeletedAt   *time.Time  `bson:"deleted_at,omitempty" json:"deleted_at,omitempty"`
 }
 
 // VehicleBrandsResponse wraps the brands catalog for Orval-typed clients.
@@ -138,26 +140,26 @@ type VehicleColorsResponse struct {
 // OwnerName/OwnerPhone/OwnerEmail are response-only (enriched live from RMI via owner_cpf);
 // they are not written on create for UI purposes.
 type Vehicle struct {
-	ID                   primitive.ObjectID `bson:"_id,omitempty" json:"id"`
-	OwnerCPF             string             `bson:"owner_cpf" json:"owner_cpf"`
-	OwnerName            string             `bson:"-" json:"owner_name"`
-	OwnerPhone           string             `bson:"-" json:"owner_phone"`
-	OwnerEmail           string             `bson:"-" json:"owner_email"`
-	DisplayName          string             `bson:"display_name" json:"display_name"`
-	BrandID              *string            `bson:"brand_id,omitempty" json:"brand_id"`
-	BrandOther           *string            `bson:"brand_other,omitempty" json:"brand_other"`
-	ModelID              *string            `bson:"model_id,omitempty" json:"model_id"`
-	ModelOther           *string            `bson:"model_other,omitempty" json:"model_other"`
-	VehicleType          VehicleType        `bson:"vehicle_type" json:"vehicle_type"`
-	Color                string             `bson:"color" json:"color"`
-	SerialNumber         string             `bson:"serial_number" json:"serial_number"`
+	ID           primitive.ObjectID `bson:"_id,omitempty" json:"id"`
+	OwnerCPF     string             `bson:"owner_cpf" json:"owner_cpf"`
+	OwnerName    string             `bson:"-" json:"owner_name"`
+	OwnerPhone   string             `bson:"-" json:"owner_phone"`
+	OwnerEmail   string             `bson:"-" json:"owner_email"`
+	DisplayName  string             `bson:"display_name" json:"display_name"`
+	BrandID      *string            `bson:"brand_id,omitempty" json:"brand_id"`
+	BrandOther   *string            `bson:"brand_other,omitempty" json:"brand_other"`
+	ModelID      *string            `bson:"model_id,omitempty" json:"model_id"`
+	ModelOther   *string            `bson:"model_other,omitempty" json:"model_other"`
+	VehicleType  VehicleType        `bson:"vehicle_type" json:"vehicle_type"`
+	Color        string             `bson:"color" json:"color"`
+	SerialNumber string             `bson:"serial_number" json:"serial_number"`
 	// RegistrationNumber is a short wallet identifier generated on create (format RJ-E-XXXXXX). Not accepted in POST/PATCH.
-	RegistrationNumber   string             `bson:"registration_number" json:"registration_number" example:"RJ-E-000001"`
-	SerialNumberPhotoURL string             `bson:"serial_number_photo_url" json:"serial_number_photo_url"`
-	VehiclePhotoURL      string             `bson:"vehicle_photo_url" json:"vehicle_photo_url"`
-	InvoicePhotoURL      *string            `bson:"invoice_photo_url" json:"invoice_photo_url" extensions:"x-nullable"`
-	HasInvoice           bool               `bson:"has_invoice" json:"has_invoice"`
-	SelfDeclaration      bool               `bson:"self_declaration" json:"self_declaration"`
+	RegistrationNumber   string  `bson:"registration_number" json:"registration_number" example:"RJ-E-000001"`
+	SerialNumberPhotoURL string  `bson:"serial_number_photo_url" json:"serial_number_photo_url"`
+	VehiclePhotoURL      string  `bson:"vehicle_photo_url" json:"vehicle_photo_url"`
+	InvoicePhotoURL      *string `bson:"invoice_photo_url" json:"invoice_photo_url" extensions:"x-nullable"`
+	HasInvoice           bool    `bson:"has_invoice" json:"has_invoice"`
+	SelfDeclaration      bool    `bson:"self_declaration" json:"self_declaration"`
 
 	// Optional file metadata for UI detail (Apêndice A.4).
 	SerialNumberPhotoFileName *string `bson:"serial_number_photo_file_name,omitempty" json:"serial_number_photo_file_name,omitempty"`
@@ -185,12 +187,14 @@ type VehicleListItem struct {
 	Color              string      `json:"color"`
 	VehiclePhotoURL    string      `json:"vehicle_photo_url"`
 	Role               VehicleRole `json:"role"`
+	ConductorID        string      `json:"conductor_id,omitempty"`
 }
 
 // VehicleDetail is the detail response including the caller's role.
 type VehicleDetail struct {
 	Vehicle
-	Role VehicleRole `json:"role"`
+	Role        VehicleRole `json:"role"`
+	ConductorID string      `json:"conductor_id,omitempty"`
 }
 
 // PaginatedVehicles is the paginated list response (pets pagination shape).

--- a/internal/models/vehicle_catalog_admin.go
+++ b/internal/models/vehicle_catalog_admin.go
@@ -1,0 +1,77 @@
+package models
+
+import (
+	"fmt"
+	"strings"
+)
+
+// VehicleBrandCreateRequest is the body for POST /admin/mobilidade/vehicle-brands.
+type VehicleBrandCreateRequest struct {
+	Name string `json:"name" binding:"required" example:"Caloi"`
+}
+
+// Validate checks create-brand rules.
+func (r *VehicleBrandCreateRequest) Validate() error {
+	if strings.TrimSpace(r.Name) == "" {
+		return fmt.Errorf("name is required")
+	}
+	return nil
+}
+
+// VehicleBrandUpdateRequest is the body for PATCH /admin/mobilidade/vehicle-brands/{brand_id}.
+type VehicleBrandUpdateRequest struct {
+	Name string `json:"name" binding:"required" example:"Caloi"`
+}
+
+// Validate checks update-brand rules.
+func (r *VehicleBrandUpdateRequest) Validate() error {
+	if strings.TrimSpace(r.Name) == "" {
+		return fmt.Errorf("name is required")
+	}
+	return nil
+}
+
+// VehicleModelCreateRequest is the body for POST /admin/mobilidade/vehicle-models.
+type VehicleModelCreateRequest struct {
+	BrandID     string      `json:"brand_id" binding:"required" example:"brand_caloi"`
+	Name        string      `json:"name" binding:"required" example:"E-Vibe"`
+	VehicleType VehicleType `json:"vehicle_type" binding:"required" example:"bicicleta_eletrica"`
+}
+
+// Validate checks create-model rules.
+func (r *VehicleModelCreateRequest) Validate() error {
+	if strings.TrimSpace(r.BrandID) == "" {
+		return fmt.Errorf("brand_id is required")
+	}
+	if strings.TrimSpace(r.Name) == "" {
+		return fmt.Errorf("name is required")
+	}
+	if !IsValidVehicleType(r.VehicleType) {
+		return fmt.Errorf("invalid vehicle_type")
+	}
+	return nil
+}
+
+// VehicleModelUpdateRequest is the body for PATCH /admin/mobilidade/vehicle-models/{model_id}.
+type VehicleModelUpdateRequest struct {
+	BrandID     *string      `json:"brand_id"`
+	Name        *string      `json:"name"`
+	VehicleType *VehicleType `json:"vehicle_type"`
+}
+
+// Validate checks update-model rules.
+func (r *VehicleModelUpdateRequest) Validate() error {
+	if r.Name != nil && strings.TrimSpace(*r.Name) == "" {
+		return fmt.Errorf("name cannot be empty")
+	}
+	if r.BrandID != nil && strings.TrimSpace(*r.BrandID) == "" {
+		return fmt.Errorf("brand_id cannot be empty")
+	}
+	if r.VehicleType != nil && !IsValidVehicleType(*r.VehicleType) {
+		return fmt.Errorf("invalid vehicle_type")
+	}
+	if r.Name == nil && r.BrandID == nil && r.VehicleType == nil {
+		return fmt.Errorf("at least one field must be provided")
+	}
+	return nil
+}

--- a/internal/services/mobilidade_catalog_admin_test.go
+++ b/internal/services/mobilidade_catalog_admin_test.go
@@ -174,6 +174,48 @@ func TestMobilidadeCatalogAdmin_BlockMutationsWhenReferencedByVehicle(t *testing
 	assert.ErrorIs(t, err, ErrMobilidadeConflict)
 }
 
+func TestVehicleService_RejectsSoftDeletedCatalogOnCreateAndUpdate(t *testing.T) {
+	catalog, vehicleSvc, cleanup := setupMobilidadeCatalogAdminTest(t)
+	defer cleanup()
+	seedMobilidadeCitizen(t, mobilidadeOwnerCPF, "Ana Souza")
+
+	brand, err := catalog.CreateBrand(context.Background(), &models.VehicleBrandCreateRequest{Name: "Temp Brand"})
+	require.NoError(t, err)
+	model, err := catalog.CreateModel(context.Background(), &models.VehicleModelCreateRequest{
+		BrandID: brand.ID, Name: "Temp Model", VehicleType: models.VehicleTypeBicicletaEletrica,
+	})
+	require.NoError(t, err)
+	require.NoError(t, catalog.DeleteModel(context.Background(), model.ID))
+
+	createReq := catalogCreateRequest()
+	createReq.BrandID = &brand.ID
+	createReq.ModelID = &model.ID
+	_, err = vehicleSvc.CreateVehicle(context.Background(), mobilidadeOwnerCPF, createReq)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrMobilidadeInvalidInput)
+
+	require.NoError(t, catalog.DeleteBrand(context.Background(), brand.ID))
+	_, err = vehicleSvc.CreateVehicle(context.Background(), mobilidadeOwnerCPF, createReq)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrMobilidadeInvalidInput)
+
+	owned, err := vehicleSvc.CreateVehicle(context.Background(), mobilidadeOwnerCPF, catalogCreateRequest())
+	require.NoError(t, err)
+
+	ghostModel, err := catalog.CreateModel(context.Background(), &models.VehicleModelCreateRequest{
+		BrandID: "brand_caloi", Name: "Ghost", VehicleType: models.VehicleTypeCiclomotor,
+	})
+	require.NoError(t, err)
+	require.NoError(t, catalog.DeleteModel(context.Background(), ghostModel.ID))
+
+	_, err = vehicleSvc.UpdateVehicle(context.Background(), mobilidadeOwnerCPF, owned.ID.Hex(), &models.VehicleUpdateRequest{
+		BrandID: strPtr("brand_caloi"),
+		ModelID: &ghostModel.ID,
+	})
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrMobilidadeInvalidInput)
+}
+
 func TestMobilidadeCatalogAdmin_DeleteBrandAfterModelsRemoved(t *testing.T) {
 	catalog, _, cleanup := setupMobilidadeCatalogAdminTest(t)
 	defer cleanup()

--- a/internal/services/mobilidade_catalog_admin_test.go
+++ b/internal/services/mobilidade_catalog_admin_test.go
@@ -1,0 +1,370 @@
+package services
+
+import (
+	"context"
+	"testing"
+
+	"github.com/prefeitura-rio/app-rmi/internal/config"
+	"github.com/prefeitura-rio/app-rmi/internal/logging"
+	"github.com/prefeitura-rio/app-rmi/internal/models"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.mongodb.org/mongo-driver/bson"
+)
+
+func setupMobilidadeCatalogAdminTest(t *testing.T) (*MobilidadeCatalogService, *VehicleService, func()) {
+	t.Helper()
+	_ = logging.InitLogger()
+	if config.AppConfig == nil {
+		config.AppConfig = &config.Config{}
+	}
+	config.AppConfig.MobilidadeVehicleCollection = "test_mobilidade_catalog_admin_vehicles"
+	config.AppConfig.MobilidadeBrandCollection = "test_mobilidade_catalog_admin_brands"
+	config.AppConfig.MobilidadeModelCollection = "test_mobilidade_catalog_admin_models"
+
+	ctx := context.Background()
+	db := config.MongoDB
+	require.NotNil(t, db)
+
+	catalog := NewMobilidadeCatalogService(db, logging.GetLogger())
+	vehicleSvc := NewVehicleService(db, NewDataManager(config.Redis, db, logging.GetLogger()), logging.GetLogger())
+
+	cleanup := func() {
+		_ = db.Collection(config.AppConfig.MobilidadeBrandCollection).Drop(ctx)
+		_ = db.Collection(config.AppConfig.MobilidadeModelCollection).Drop(ctx)
+		_ = db.Collection(config.AppConfig.MobilidadeVehicleCollection).Drop(ctx)
+	}
+	cleanup()
+	seedMobilidadeCatalog(t)
+
+	return catalog, vehicleSvc, cleanup
+}
+
+func TestMobilidadeCatalogAdmin_CreateBrandAndModel(t *testing.T) {
+	catalog, _, cleanup := setupMobilidadeCatalogAdminTest(t)
+	defer cleanup()
+
+	brand, err := catalog.CreateBrand(context.Background(), &models.VehicleBrandCreateRequest{Name: "Monark"})
+	require.NoError(t, err)
+	assert.Equal(t, "brand_monark", brand.ID)
+	assert.False(t, brand.IsOther)
+
+	model, err := catalog.CreateModel(context.Background(), &models.VehicleModelCreateRequest{
+		BrandID:     brand.ID,
+		Name:        "E-Bike X",
+		VehicleType: models.VehicleTypeBicicletaEletrica,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "model_monark_e_bike_x", model.ID)
+	assert.Equal(t, brand.ID, model.BrandID)
+
+	brands, err := catalog.ListBrands(context.Background())
+	require.NoError(t, err)
+	ids := map[string]bool{}
+	for _, b := range brands {
+		ids[b.ID] = true
+	}
+	assert.True(t, ids["brand_monark"])
+
+	modelsList, err := catalog.ListModelsByBrand(context.Background(), brand.ID)
+	require.NoError(t, err)
+	require.Len(t, modelsList, 1)
+	assert.Equal(t, model.ID, modelsList[0].ID)
+}
+
+func TestMobilidadeCatalogAdmin_UniqueNames(t *testing.T) {
+	catalog, _, cleanup := setupMobilidadeCatalogAdminTest(t)
+	defer cleanup()
+
+	_, err := catalog.CreateBrand(context.Background(), &models.VehicleBrandCreateRequest{Name: "Caloi"})
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrMobilidadeConflict)
+
+	_, err = catalog.CreateModel(context.Background(), &models.VehicleModelCreateRequest{
+		BrandID: "brand_caloi", Name: "E-Vibe", VehicleType: models.VehicleTypeBicicletaEletrica,
+	})
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrMobilidadeConflict)
+}
+
+func TestMobilidadeCatalogAdmin_SentinelProtection(t *testing.T) {
+	catalog, _, cleanup := setupMobilidadeCatalogAdminTest(t)
+	defer cleanup()
+
+	_, err := catalog.UpdateBrand(context.Background(), models.VehicleBrandOutroID, &models.VehicleBrandUpdateRequest{Name: "X"})
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrMobilidadeInvalidInput)
+
+	err = catalog.DeleteBrand(context.Background(), models.VehicleBrandOutroID)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrMobilidadeInvalidInput)
+
+	_, err = catalog.UpdateModel(context.Background(), models.VehicleModelOutroID, &models.VehicleModelUpdateRequest{
+		Name: func() *string { s := "X"; return &s }(),
+	})
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrMobilidadeInvalidInput)
+
+	err = catalog.DeleteModel(context.Background(), models.VehicleModelOutroID)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrMobilidadeInvalidInput)
+}
+
+func TestMobilidadeCatalogAdmin_DeleteBrandWithModelsConflict(t *testing.T) {
+	catalog, _, cleanup := setupMobilidadeCatalogAdminTest(t)
+	defer cleanup()
+
+	err := catalog.DeleteBrand(context.Background(), "brand_caloi")
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrMobilidadeConflict)
+}
+
+func TestMobilidadeCatalogAdmin_SoftDeleteHidesFromPublicList(t *testing.T) {
+	catalog, _, cleanup := setupMobilidadeCatalogAdminTest(t)
+	defer cleanup()
+
+	brand, err := catalog.CreateBrand(context.Background(), &models.VehicleBrandCreateRequest{Name: "Temp Brand"})
+	require.NoError(t, err)
+
+	require.NoError(t, catalog.DeleteBrand(context.Background(), brand.ID))
+
+	public, err := catalog.ListBrands(context.Background())
+	require.NoError(t, err)
+	for _, b := range public {
+		assert.NotEqual(t, brand.ID, b.ID)
+	}
+
+	admin, err := catalog.ListBrandsAdmin(context.Background())
+	require.NoError(t, err)
+	found := false
+	for _, b := range admin {
+		if b.ID == brand.ID {
+			found = true
+			assert.NotNil(t, b.DeletedAt)
+		}
+	}
+	assert.True(t, found)
+}
+
+func TestMobilidadeCatalogAdmin_BlockMutationsWhenReferencedByVehicle(t *testing.T) {
+	catalog, vehicleSvc, cleanup := setupMobilidadeCatalogAdminTest(t)
+	defer cleanup()
+	seedMobilidadeCitizen(t, mobilidadeOwnerCPF, "Ana Souza")
+
+	created, err := vehicleSvc.CreateVehicle(context.Background(), mobilidadeOwnerCPF, catalogCreateRequest())
+	require.NoError(t, err)
+	require.NotNil(t, created.BrandID)
+	require.NotNil(t, created.ModelID)
+
+	_, err = catalog.UpdateBrand(context.Background(), *created.BrandID, &models.VehicleBrandUpdateRequest{Name: "Caloi Nova"})
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrMobilidadeConflict)
+
+	err = catalog.DeleteBrand(context.Background(), *created.BrandID)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrMobilidadeConflict)
+
+	newName := "E-Vibe Pro"
+	_, err = catalog.UpdateModel(context.Background(), *created.ModelID, &models.VehicleModelUpdateRequest{Name: &newName})
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrMobilidadeConflict)
+
+	err = catalog.DeleteModel(context.Background(), *created.ModelID)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrMobilidadeConflict)
+}
+
+func TestMobilidadeCatalogAdmin_DeleteBrandAfterModelsRemoved(t *testing.T) {
+	catalog, _, cleanup := setupMobilidadeCatalogAdminTest(t)
+	defer cleanup()
+
+	brand, err := catalog.CreateBrand(context.Background(), &models.VehicleBrandCreateRequest{Name: "Solo Brand"})
+	require.NoError(t, err)
+	model, err := catalog.CreateModel(context.Background(), &models.VehicleModelCreateRequest{
+		BrandID: brand.ID, Name: "Solo Model", VehicleType: models.VehicleTypeCiclomotor,
+	})
+	require.NoError(t, err)
+
+	require.NoError(t, catalog.DeleteModel(context.Background(), model.ID))
+	require.NoError(t, catalog.DeleteBrand(context.Background(), brand.ID))
+
+	_, err = catalog.findActiveBrand(context.Background(), brand.ID)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrCatalogBrandNotFound)
+
+	var stored bson.M
+	err = config.MongoDB.Collection(config.AppConfig.MobilidadeBrandCollection).FindOne(
+		context.Background(), bson.M{"_id": brand.ID},
+	).Decode(&stored)
+	require.NoError(t, err)
+	assert.NotNil(t, stored["deleted_at"])
+}
+
+func TestMobilidadeCatalogAdmin_NotFoundAndValidation(t *testing.T) {
+	catalog, _, cleanup := setupMobilidadeCatalogAdminTest(t)
+	defer cleanup()
+
+	_, err := catalog.UpdateBrand(context.Background(), "brand_missing", &models.VehicleBrandUpdateRequest{Name: "X"})
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrCatalogBrandNotFound)
+
+	err = catalog.DeleteBrand(context.Background(), "brand_missing")
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrCatalogBrandNotFound)
+
+	_, err = catalog.UpdateModel(context.Background(), "model_missing", &models.VehicleModelUpdateRequest{
+		Name: func() *string { s := "X"; return &s }(),
+	})
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrCatalogModelNotFound)
+
+	err = catalog.DeleteModel(context.Background(), "model_missing")
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrCatalogModelNotFound)
+
+	_, err = catalog.CreateBrand(context.Background(), &models.VehicleBrandCreateRequest{Name: "   "})
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrMobilidadeInvalidInput)
+
+	_, err = catalog.CreateModel(context.Background(), &models.VehicleModelCreateRequest{
+		BrandID: "brand_caloi", Name: "Bad", VehicleType: models.VehicleType("invalid"),
+	})
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrMobilidadeInvalidInput)
+
+	_, err = catalog.CreateModel(context.Background(), &models.VehicleModelCreateRequest{
+		BrandID: "brand_does_not_exist", Name: "X", VehicleType: models.VehicleTypeCiclomotor,
+	})
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrCatalogBrandNotFound)
+
+	_, err = catalog.CreateModel(context.Background(), &models.VehicleModelCreateRequest{
+		BrandID: models.VehicleBrandOutroID, Name: "X", VehicleType: models.VehicleTypeCiclomotor,
+	})
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrMobilidadeInvalidInput)
+
+	outroBrand := models.VehicleBrandOutroID
+	_, err = catalog.UpdateModel(context.Background(), "model_e-vibe", &models.VehicleModelUpdateRequest{
+		BrandID: &outroBrand,
+	})
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrMobilidadeInvalidInput)
+
+	emptyName := "   "
+	_, err = catalog.UpdateModel(context.Background(), "model_e-vibe", &models.VehicleModelUpdateRequest{
+		Name: &emptyName,
+	})
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrMobilidadeInvalidInput)
+
+	_, err = catalog.UpdateModel(context.Background(), "model_e-vibe", &models.VehicleModelUpdateRequest{})
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrMobilidadeInvalidInput)
+}
+
+func TestMobilidadeCatalogAdmin_SoftDeletedNotFoundOnMutate(t *testing.T) {
+	catalog, _, cleanup := setupMobilidadeCatalogAdminTest(t)
+	defer cleanup()
+
+	brand, err := catalog.CreateBrand(context.Background(), &models.VehicleBrandCreateRequest{Name: "Ghost Brand"})
+	require.NoError(t, err)
+	require.NoError(t, catalog.DeleteBrand(context.Background(), brand.ID))
+
+	_, err = catalog.UpdateBrand(context.Background(), brand.ID, &models.VehicleBrandUpdateRequest{Name: "Still Ghost"})
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrCatalogBrandNotFound)
+
+	err = catalog.DeleteBrand(context.Background(), brand.ID)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrCatalogBrandNotFound)
+
+	model, err := catalog.CreateModel(context.Background(), &models.VehicleModelCreateRequest{
+		BrandID: "brand_caloi", Name: "Ghost Model", VehicleType: models.VehicleTypeAutopropelido,
+	})
+	require.NoError(t, err)
+	require.NoError(t, catalog.DeleteModel(context.Background(), model.ID))
+
+	newName := "Still Ghost"
+	_, err = catalog.UpdateModel(context.Background(), model.ID, &models.VehicleModelUpdateRequest{Name: &newName})
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrCatalogModelNotFound)
+
+	err = catalog.DeleteModel(context.Background(), model.ID)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrCatalogModelNotFound)
+}
+
+func TestMobilidadeCatalogAdmin_SoftDeleteModelHidesFromPublicList(t *testing.T) {
+	catalog, _, cleanup := setupMobilidadeCatalogAdminTest(t)
+	defer cleanup()
+
+	model, err := catalog.CreateModel(context.Background(), &models.VehicleModelCreateRequest{
+		BrandID: "brand_caloi", Name: "Temp Model", VehicleType: models.VehicleTypeCiclomotor,
+	})
+	require.NoError(t, err)
+	require.NoError(t, catalog.DeleteModel(context.Background(), model.ID))
+
+	public, err := catalog.ListModelsByBrand(context.Background(), "brand_caloi")
+	require.NoError(t, err)
+	for _, m := range public {
+		assert.NotEqual(t, model.ID, m.ID)
+	}
+
+	admin, err := catalog.ListModelsAdmin(context.Background(), "brand_caloi")
+	require.NoError(t, err)
+	found := false
+	for _, m := range admin {
+		if m.ID == model.ID {
+			found = true
+			assert.NotNil(t, m.DeletedAt)
+		}
+	}
+	assert.True(t, found)
+}
+
+func TestMobilidadeCatalogAdmin_UpdateBrandAndModelSuccess(t *testing.T) {
+	catalog, _, cleanup := setupMobilidadeCatalogAdminTest(t)
+	defer cleanup()
+
+	brand, err := catalog.CreateBrand(context.Background(), &models.VehicleBrandCreateRequest{Name: "Oggi"})
+	require.NoError(t, err)
+	updatedBrand, err := catalog.UpdateBrand(context.Background(), brand.ID, &models.VehicleBrandUpdateRequest{Name: "Oggi Bikes"})
+	require.NoError(t, err)
+	assert.Equal(t, "Oggi Bikes", updatedBrand.Name)
+
+	model, err := catalog.CreateModel(context.Background(), &models.VehicleModelCreateRequest{
+		BrandID: brand.ID, Name: "Hacker", VehicleType: models.VehicleTypeBicicletaEletrica,
+	})
+	require.NoError(t, err)
+
+	newType := models.VehicleTypeCiclomotor
+	newName := "Hacker Pro"
+	updatedModel, err := catalog.UpdateModel(context.Background(), model.ID, &models.VehicleModelUpdateRequest{
+		Name: &newName, VehicleType: &newType, BrandID: &brand.ID,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "Hacker Pro", updatedModel.Name)
+	assert.Equal(t, models.VehicleTypeCiclomotor, updatedModel.VehicleType)
+	assert.Equal(t, brand.ID, updatedModel.BrandID)
+}
+
+func TestMobilidadeCatalogAdmin_MoveModelToOtherBrand(t *testing.T) {
+	catalog, _, cleanup := setupMobilidadeCatalogAdminTest(t)
+	defer cleanup()
+
+	target, err := catalog.CreateBrand(context.Background(), &models.VehicleBrandCreateRequest{Name: "Sense"})
+	require.NoError(t, err)
+
+	moved, err := catalog.UpdateModel(context.Background(), "model_e-vibe", &models.VehicleModelUpdateRequest{
+		BrandID: &target.ID,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, target.ID, moved.BrandID)
+
+	caloiModels, err := catalog.ListModelsByBrand(context.Background(), "brand_caloi")
+	require.NoError(t, err)
+	for _, m := range caloiModels {
+		assert.NotEqual(t, "model_e-vibe", m.ID)
+	}
+}

--- a/internal/services/mobilidade_catalog_service.go
+++ b/internal/services/mobilidade_catalog_service.go
@@ -46,6 +46,14 @@ func catalogActiveFilter() bson.M {
 	}
 }
 
+// withCatalogActive merges base with the active-catalog filter (excludes soft-deleted).
+func withCatalogActive(base bson.M) bson.M {
+	out := bson.M{}
+	maps.Copy(out, base)
+	maps.Copy(out, catalogActiveFilter())
+	return out
+}
+
 func (s *MobilidadeCatalogService) brandsColl() *mongo.Collection {
 	return s.database.Collection(config.AppConfig.MobilidadeBrandCollection)
 }

--- a/internal/services/mobilidade_catalog_service.go
+++ b/internal/services/mobilidade_catalog_service.go
@@ -2,11 +2,17 @@ package services
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"maps"
+	"regexp"
+	"strings"
+	"time"
 
 	"github.com/prefeitura-rio/app-rmi/internal/config"
 	"github.com/prefeitura-rio/app-rmi/internal/logging"
 	"github.com/prefeitura-rio/app-rmi/internal/models"
+	"github.com/prefeitura-rio/app-rmi/internal/utils"
 	"go.mongodb.org/mongo-driver/bson"
 	"go.mongodb.org/mongo-driver/mongo"
 	"go.mongodb.org/mongo-driver/mongo/options"
@@ -31,11 +37,40 @@ func InitMobilidadeCatalogService() {
 	MobilidadeCatalogServiceInstance = NewMobilidadeCatalogService(config.MongoDB, logging.GetLogger())
 }
 
-// ListBrands returns seeded vehicle brands ordered by name.
+func catalogActiveFilter() bson.M {
+	return bson.M{
+		"$or": []bson.M{
+			{"deleted_at": nil},
+			{"deleted_at": bson.M{"$exists": false}},
+		},
+	}
+}
+
+func (s *MobilidadeCatalogService) brandsColl() *mongo.Collection {
+	return s.database.Collection(config.AppConfig.MobilidadeBrandCollection)
+}
+
+func (s *MobilidadeCatalogService) modelsColl() *mongo.Collection {
+	return s.database.Collection(config.AppConfig.MobilidadeModelCollection)
+}
+
+func (s *MobilidadeCatalogService) vehiclesColl() *mongo.Collection {
+	return s.database.Collection(config.AppConfig.MobilidadeVehicleCollection)
+}
+
+// ListBrands returns active vehicle brands ordered by name (citizen form).
 func (s *MobilidadeCatalogService) ListBrands(ctx context.Context) ([]models.VehicleBrand, error) {
-	coll := s.database.Collection(config.AppConfig.MobilidadeBrandCollection)
+	return s.listBrands(ctx, catalogActiveFilter())
+}
+
+// ListBrandsAdmin returns all brands including soft-deleted (admin).
+func (s *MobilidadeCatalogService) ListBrandsAdmin(ctx context.Context) ([]models.VehicleBrand, error) {
+	return s.listBrands(ctx, bson.M{})
+}
+
+func (s *MobilidadeCatalogService) listBrands(ctx context.Context, filter bson.M) ([]models.VehicleBrand, error) {
 	opts := options.Find().SetSort(bson.D{{Key: "name", Value: 1}})
-	cursor, err := coll.Find(ctx, bson.M{}, opts)
+	cursor, err := s.brandsColl().Find(ctx, filter, opts)
 	if err != nil {
 		return nil, fmt.Errorf("list brands: %w", err)
 	}
@@ -51,14 +86,28 @@ func (s *MobilidadeCatalogService) ListBrands(ctx context.Context) ([]models.Veh
 	return brands, nil
 }
 
-// ListModelsByBrand returns models for brandID (required).
+// ListModelsByBrand returns active models for brandID (citizen form).
 func (s *MobilidadeCatalogService) ListModelsByBrand(ctx context.Context, brandID string) ([]models.VehicleModel, error) {
 	if brandID == "" {
 		return nil, fmt.Errorf("%w: brand_id is required", ErrMobilidadeInvalidInput)
 	}
-	coll := s.database.Collection(config.AppConfig.MobilidadeModelCollection)
+	filter := bson.M{"brand_id": brandID}
+	maps.Copy(filter, catalogActiveFilter())
+	return s.listModels(ctx, filter)
+}
+
+// ListModelsAdmin returns all models, optionally filtered by brand_id (admin).
+func (s *MobilidadeCatalogService) ListModelsAdmin(ctx context.Context, brandID string) ([]models.VehicleModel, error) {
+	filter := bson.M{}
+	if brandID != "" {
+		filter["brand_id"] = brandID
+	}
+	return s.listModels(ctx, filter)
+}
+
+func (s *MobilidadeCatalogService) listModels(ctx context.Context, filter bson.M) ([]models.VehicleModel, error) {
 	opts := options.Find().SetSort(bson.D{{Key: "name", Value: 1}})
-	cursor, err := coll.Find(ctx, bson.M{"brand_id": brandID}, opts)
+	cursor, err := s.modelsColl().Find(ctx, filter, opts)
 	if err != nil {
 		return nil, fmt.Errorf("list models: %w", err)
 	}
@@ -77,4 +126,382 @@ func (s *MobilidadeCatalogService) ListModelsByBrand(ctx context.Context, brandI
 // ListColors returns the fixed color catalog.
 func (s *MobilidadeCatalogService) ListColors(ctx context.Context) ([]string, error) {
 	return models.VehicleColors(), nil
+}
+
+// CreateBrand registers a new catalog brand (admin).
+func (s *MobilidadeCatalogService) CreateBrand(ctx context.Context, req *models.VehicleBrandCreateRequest) (*models.VehicleBrand, error) {
+	if err := req.Validate(); err != nil {
+		return nil, fmt.Errorf("%w: %s", ErrMobilidadeInvalidInput, err.Error())
+	}
+	name := strings.TrimSpace(req.Name)
+	if err := s.ensureBrandNameUnique(ctx, name, ""); err != nil {
+		return nil, err
+	}
+
+	id := utils.MobilidadeBrandIDFromName(name)
+	var existing models.VehicleBrand
+	err := s.brandsColl().FindOne(ctx, bson.M{"_id": id}).Decode(&existing)
+	if err == nil {
+		if existing.DeletedAt == nil {
+			return nil, fmt.Errorf("%w: brand already exists", ErrMobilidadeConflict)
+		}
+		return nil, fmt.Errorf("%w: brand id already used by inactive entry", ErrMobilidadeConflict)
+	}
+	if !errors.Is(err, mongo.ErrNoDocuments) {
+		return nil, fmt.Errorf("check brand id: %w", err)
+	}
+
+	brand := models.VehicleBrand{
+		ID:      id,
+		Name:    name,
+		IsOther: false,
+	}
+	if _, err := s.brandsColl().InsertOne(ctx, brand); err != nil {
+		if mongo.IsDuplicateKeyError(err) {
+			return nil, ErrMobilidadeConflict
+		}
+		return nil, fmt.Errorf("insert brand: %w", err)
+	}
+	return &brand, nil
+}
+
+// UpdateBrand updates an active brand name (admin).
+func (s *MobilidadeCatalogService) UpdateBrand(ctx context.Context, brandID string, req *models.VehicleBrandUpdateRequest) (*models.VehicleBrand, error) {
+	if err := req.Validate(); err != nil {
+		return nil, fmt.Errorf("%w: %s", ErrMobilidadeInvalidInput, err.Error())
+	}
+	if err := s.rejectCatalogSentinelBrand(brandID); err != nil {
+		return nil, err
+	}
+
+	brand, err := s.findActiveBrand(ctx, brandID)
+	if err != nil {
+		return nil, err
+	}
+	if err := s.ensureBrandReferencedByVehicle(ctx, brandID); err != nil {
+		return nil, err
+	}
+
+	name := strings.TrimSpace(req.Name)
+	if err := s.ensureBrandNameUnique(ctx, name, brandID); err != nil {
+		return nil, err
+	}
+
+	res, err := s.brandsColl().UpdateOne(ctx,
+		bson.M{"_id": brandID, "deleted_at": nil},
+		bson.M{"$set": bson.M{"name": name}},
+	)
+	if err != nil {
+		return nil, fmt.Errorf("update brand: %w", err)
+	}
+	if res.MatchedCount == 0 {
+		return nil, ErrCatalogBrandNotFound
+	}
+	brand.Name = name
+	return brand, nil
+}
+
+// DeleteBrand soft-deletes a brand when it has no active models or vehicle references (admin).
+func (s *MobilidadeCatalogService) DeleteBrand(ctx context.Context, brandID string) error {
+	if err := s.rejectCatalogSentinelBrand(brandID); err != nil {
+		return err
+	}
+
+	if _, err := s.findActiveBrand(ctx, brandID); err != nil {
+		return err
+	}
+	if err := s.ensureBrandReferencedByVehicle(ctx, brandID); err != nil {
+		return err
+	}
+
+	activeModels, err := s.modelsColl().CountDocuments(ctx, bson.M{
+		"brand_id": brandID,
+		"$or": []bson.M{
+			{"deleted_at": nil},
+			{"deleted_at": bson.M{"$exists": false}},
+		},
+	})
+	if err != nil {
+		return fmt.Errorf("count brand models: %w", err)
+	}
+	if activeModels > 0 {
+		return fmt.Errorf("%w: brand still has active models", ErrMobilidadeConflict)
+	}
+
+	now := time.Now().UTC()
+	res, err := s.brandsColl().UpdateOne(ctx,
+		bson.M{"_id": brandID, "deleted_at": nil},
+		bson.M{"$set": bson.M{"deleted_at": now}},
+	)
+	if err != nil {
+		return fmt.Errorf("delete brand: %w", err)
+	}
+	if res.MatchedCount == 0 {
+		return ErrCatalogBrandNotFound
+	}
+	return nil
+}
+
+// CreateModel registers a new catalog model under a brand (admin).
+func (s *MobilidadeCatalogService) CreateModel(ctx context.Context, req *models.VehicleModelCreateRequest) (*models.VehicleModel, error) {
+	if err := req.Validate(); err != nil {
+		return nil, fmt.Errorf("%w: %s", ErrMobilidadeInvalidInput, err.Error())
+	}
+	brandID := strings.TrimSpace(req.BrandID)
+	if brandID == models.VehicleBrandOutroID {
+		return nil, fmt.Errorf("%w: cannot add models to sentinel brand", ErrMobilidadeInvalidInput)
+	}
+
+	brand, err := s.findActiveBrand(ctx, brandID)
+	if err != nil {
+		return nil, err
+	}
+	if brand.IsOther {
+		return nil, fmt.Errorf("%w: cannot add models to sentinel brand", ErrMobilidadeInvalidInput)
+	}
+
+	name := strings.TrimSpace(req.Name)
+	if err := s.ensureModelNameUnique(ctx, brandID, name, ""); err != nil {
+		return nil, err
+	}
+
+	id := utils.MobilidadeModelIDFromBrandAndName(brand.Name, name)
+	var existing models.VehicleModel
+	err = s.modelsColl().FindOne(ctx, bson.M{"_id": id}).Decode(&existing)
+	if err == nil {
+		if existing.DeletedAt == nil {
+			return nil, fmt.Errorf("%w: model already exists", ErrMobilidadeConflict)
+		}
+		return nil, fmt.Errorf("%w: model id already used by inactive entry", ErrMobilidadeConflict)
+	}
+	if !errors.Is(err, mongo.ErrNoDocuments) {
+		return nil, fmt.Errorf("check model id: %w", err)
+	}
+
+	model := models.VehicleModel{
+		ID:          id,
+		BrandID:     brandID,
+		Name:        name,
+		VehicleType: req.VehicleType,
+		IsOther:     false,
+	}
+	if _, err := s.modelsColl().InsertOne(ctx, model); err != nil {
+		if mongo.IsDuplicateKeyError(err) {
+			return nil, ErrMobilidadeConflict
+		}
+		return nil, fmt.Errorf("insert model: %w", err)
+	}
+	return &model, nil
+}
+
+// UpdateModel updates an active model (admin).
+func (s *MobilidadeCatalogService) UpdateModel(ctx context.Context, modelID string, req *models.VehicleModelUpdateRequest) (*models.VehicleModel, error) {
+	if err := req.Validate(); err != nil {
+		return nil, fmt.Errorf("%w: %s", ErrMobilidadeInvalidInput, err.Error())
+	}
+	if err := s.rejectCatalogSentinelModel(modelID); err != nil {
+		return nil, err
+	}
+
+	model, err := s.findActiveModel(ctx, modelID)
+	if err != nil {
+		return nil, err
+	}
+	if err := s.ensureModelReferencedByVehicle(ctx, modelID); err != nil {
+		return nil, err
+	}
+
+	targetBrandID := model.BrandID
+	if req.BrandID != nil {
+		targetBrandID = strings.TrimSpace(*req.BrandID)
+		if targetBrandID == models.VehicleBrandOutroID {
+			return nil, fmt.Errorf("%w: cannot move model to sentinel brand", ErrMobilidadeInvalidInput)
+		}
+		brand, err := s.findActiveBrand(ctx, targetBrandID)
+		if err != nil {
+			return nil, err
+		}
+		if brand.IsOther {
+			return nil, fmt.Errorf("%w: cannot move model to sentinel brand", ErrMobilidadeInvalidInput)
+		}
+	}
+
+	targetName := model.Name
+	if req.Name != nil {
+		targetName = strings.TrimSpace(*req.Name)
+	}
+	if err := s.ensureModelNameUnique(ctx, targetBrandID, targetName, modelID); err != nil {
+		return nil, err
+	}
+
+	set := bson.M{}
+	if req.Name != nil {
+		set["name"] = targetName
+	}
+	if req.BrandID != nil {
+		set["brand_id"] = targetBrandID
+	}
+	if req.VehicleType != nil {
+		set["vehicle_type"] = *req.VehicleType
+	}
+
+	res, err := s.modelsColl().UpdateOne(ctx,
+		bson.M{"_id": modelID, "deleted_at": nil},
+		bson.M{"$set": set},
+	)
+	if err != nil {
+		return nil, fmt.Errorf("update model: %w", err)
+	}
+	if res.MatchedCount == 0 {
+		return nil, ErrCatalogModelNotFound
+	}
+
+	updated, err := s.findActiveModel(ctx, modelID)
+	if err != nil {
+		return nil, err
+	}
+	return updated, nil
+}
+
+// DeleteModel soft-deletes a model when not referenced by vehicles (admin).
+func (s *MobilidadeCatalogService) DeleteModel(ctx context.Context, modelID string) error {
+	if err := s.rejectCatalogSentinelModel(modelID); err != nil {
+		return err
+	}
+
+	if _, err := s.findActiveModel(ctx, modelID); err != nil {
+		return err
+	}
+	if err := s.ensureModelReferencedByVehicle(ctx, modelID); err != nil {
+		return err
+	}
+
+	now := time.Now().UTC()
+	res, err := s.modelsColl().UpdateOne(ctx,
+		bson.M{"_id": modelID, "deleted_at": nil},
+		bson.M{"$set": bson.M{"deleted_at": now}},
+	)
+	if err != nil {
+		return fmt.Errorf("delete model: %w", err)
+	}
+	if res.MatchedCount == 0 {
+		return ErrCatalogModelNotFound
+	}
+	return nil
+}
+
+func (s *MobilidadeCatalogService) findActiveBrand(ctx context.Context, brandID string) (*models.VehicleBrand, error) {
+	var brand models.VehicleBrand
+	filter := bson.M{"_id": brandID}
+	maps.Copy(filter, catalogActiveFilter())
+	err := s.brandsColl().FindOne(ctx, filter).Decode(&brand)
+	if errors.Is(err, mongo.ErrNoDocuments) {
+		return nil, ErrCatalogBrandNotFound
+	}
+	if err != nil {
+		return nil, fmt.Errorf("find brand: %w", err)
+	}
+	return &brand, nil
+}
+
+func (s *MobilidadeCatalogService) findActiveModel(ctx context.Context, modelID string) (*models.VehicleModel, error) {
+	var model models.VehicleModel
+	filter := bson.M{"_id": modelID}
+	maps.Copy(filter, catalogActiveFilter())
+	err := s.modelsColl().FindOne(ctx, filter).Decode(&model)
+	if errors.Is(err, mongo.ErrNoDocuments) {
+		return nil, ErrCatalogModelNotFound
+	}
+	if err != nil {
+		return nil, fmt.Errorf("find model: %w", err)
+	}
+	return &model, nil
+}
+
+func (s *MobilidadeCatalogService) rejectCatalogSentinelBrand(brandID string) error {
+	if brandID == models.VehicleBrandOutroID {
+		return fmt.Errorf("%w: sentinel brand cannot be modified", ErrMobilidadeInvalidInput)
+	}
+	return nil
+}
+
+func (s *MobilidadeCatalogService) rejectCatalogSentinelModel(modelID string) error {
+	if modelID == models.VehicleModelOutroID {
+		return fmt.Errorf("%w: sentinel model cannot be modified", ErrMobilidadeInvalidInput)
+	}
+	return nil
+}
+
+func (s *MobilidadeCatalogService) ensureBrandNameUnique(ctx context.Context, name, excludeID string) error {
+	filter := bson.M{
+		"name": caseInsensitiveExactRegex(name),
+	}
+	maps.Copy(filter, catalogActiveFilter())
+	if excludeID != "" {
+		filter["_id"] = bson.M{"$ne": excludeID}
+	}
+	count, err := s.brandsColl().CountDocuments(ctx, filter)
+	if err != nil {
+		return fmt.Errorf("check brand name: %w", err)
+	}
+	if count > 0 {
+		return fmt.Errorf("%w: brand name already exists", ErrMobilidadeConflict)
+	}
+	return nil
+}
+
+func (s *MobilidadeCatalogService) ensureModelNameUnique(ctx context.Context, brandID, name, excludeID string) error {
+	filter := bson.M{
+		"brand_id": brandID,
+		"name":     caseInsensitiveExactRegex(name),
+	}
+	maps.Copy(filter, catalogActiveFilter())
+	if excludeID != "" {
+		filter["_id"] = bson.M{"$ne": excludeID}
+	}
+	count, err := s.modelsColl().CountDocuments(ctx, filter)
+	if err != nil {
+		return fmt.Errorf("check model name: %w", err)
+	}
+	if count > 0 {
+		return fmt.Errorf("%w: model name already exists for brand", ErrMobilidadeConflict)
+	}
+	return nil
+}
+
+func (s *MobilidadeCatalogService) ensureBrandReferencedByVehicle(ctx context.Context, brandID string) error {
+	count, err := s.countActiveVehicles(ctx, bson.M{"brand_id": brandID})
+	if err != nil {
+		return err
+	}
+	if count > 0 {
+		return fmt.Errorf("%w: brand is referenced by registered vehicles", ErrMobilidadeConflict)
+	}
+	return nil
+}
+
+func (s *MobilidadeCatalogService) ensureModelReferencedByVehicle(ctx context.Context, modelID string) error {
+	count, err := s.countActiveVehicles(ctx, bson.M{"model_id": modelID})
+	if err != nil {
+		return err
+	}
+	if count > 0 {
+		return fmt.Errorf("%w: model is referenced by registered vehicles", ErrMobilidadeConflict)
+	}
+	return nil
+}
+
+func (s *MobilidadeCatalogService) countActiveVehicles(ctx context.Context, catalogFilter bson.M) (int64, error) {
+	filter := bson.M{"deleted_at": nil}
+	maps.Copy(filter, catalogFilter)
+	count, err := s.vehiclesColl().CountDocuments(ctx, filter)
+	if err != nil {
+		return 0, fmt.Errorf("count vehicles: %w", err)
+	}
+	return count, nil
+}
+
+func caseInsensitiveExactRegex(value string) bson.M {
+	escaped := regexp.QuoteMeta(strings.TrimSpace(value))
+	return bson.M{"$regex": fmt.Sprintf("^%s$", escaped), "$options": "i"}
 }

--- a/internal/services/vehicle_conductor_service.go
+++ b/internal/services/vehicle_conductor_service.go
@@ -244,7 +244,7 @@ func (s *VehicleConductorService) InviteConductor(ctx context.Context, cpf, vehi
 	return &link, nil
 }
 
-// enrichConductorForResponse: pending keeps invite snapshot; accepted overlays live RMI profile.
+// enrichConductorForResponse: pending keeps invite snapshot; accepted replaces name/email/phone with live RMI profile.
 func (s *VehicleConductorService) enrichConductorForResponse(ctx context.Context, link *models.VehicleConductor) {
 	if link == nil || link.ConductorCPF == "" {
 		return
@@ -253,15 +253,9 @@ func (s *VehicleConductorService) enrichConductorForResponse(ctx context.Context
 		return
 	}
 	name, phone, email := loadCitizenContactProfile(ctx, s.database, s.dataManager, s.logger, link.ConductorCPF)
-	if name != "" {
-		link.ConductorName = name
-	}
-	if email != "" {
-		link.NotifyEmail = email
-	}
-	if phone != "" {
-		link.Phone = phone
-	}
+	link.ConductorName = name
+	link.NotifyEmail = email
+	link.Phone = phone
 }
 
 func mapConductorInsertError(err error) error {

--- a/internal/services/vehicle_service.go
+++ b/internal/services/vehicle_service.go
@@ -525,7 +525,7 @@ func (s *VehicleService) resolveCreateCatalogFields(ctx context.Context, req *mo
 	catalogFlow := req.BrandID != nil && *req.BrandID != "" && req.ModelID != nil && *req.ModelID != ""
 	if catalogFlow {
 		var model models.VehicleModel
-		err := s.models().FindOne(ctx, bson.M{"_id": *req.ModelID, "brand_id": *req.BrandID}).Decode(&model)
+		err := s.models().FindOne(ctx, withCatalogActive(bson.M{"_id": *req.ModelID, "brand_id": *req.BrandID})).Decode(&model)
 		if errors.Is(err, mongo.ErrNoDocuments) {
 			return "", nil, nil, nil, nil, fmt.Errorf("%w: model not found for brand", ErrMobilidadeInvalidInput)
 		}
@@ -533,7 +533,7 @@ func (s *VehicleService) resolveCreateCatalogFields(ctx context.Context, req *mo
 			return "", nil, nil, nil, nil, fmt.Errorf("load model: %w", err)
 		}
 		var brand models.VehicleBrand
-		err = s.brands().FindOne(ctx, bson.M{"_id": *req.BrandID}).Decode(&brand)
+		err = s.brands().FindOne(ctx, withCatalogActive(bson.M{"_id": *req.BrandID})).Decode(&brand)
 		if errors.Is(err, mongo.ErrNoDocuments) {
 			return "", nil, nil, nil, nil, fmt.Errorf("%w: brand not found", ErrMobilidadeInvalidInput)
 		}
@@ -621,7 +621,7 @@ func (s *VehicleService) applyUpdateCatalogFields(ctx context.Context, current *
 	catalogFlow := brandID != nil && *brandID != "" && modelID != nil && *modelID != ""
 	if catalogFlow {
 		var model models.VehicleModel
-		err := s.models().FindOne(ctx, bson.M{"_id": *modelID, "brand_id": *brandID}).Decode(&model)
+		err := s.models().FindOne(ctx, withCatalogActive(bson.M{"_id": *modelID, "brand_id": *brandID})).Decode(&model)
 		if errors.Is(err, mongo.ErrNoDocuments) {
 			return fmt.Errorf("%w: model not found for brand", ErrMobilidadeInvalidInput)
 		}
@@ -629,7 +629,7 @@ func (s *VehicleService) applyUpdateCatalogFields(ctx context.Context, current *
 			return fmt.Errorf("load model: %w", err)
 		}
 		var brand models.VehicleBrand
-		err = s.brands().FindOne(ctx, bson.M{"_id": *brandID}).Decode(&brand)
+		err = s.brands().FindOne(ctx, withCatalogActive(bson.M{"_id": *brandID})).Decode(&brand)
 		if errors.Is(err, mongo.ErrNoDocuments) {
 			return fmt.Errorf("%w: brand not found", ErrMobilidadeInvalidInput)
 		}

--- a/internal/services/vehicle_service.go
+++ b/internal/services/vehicle_service.go
@@ -33,6 +33,10 @@ var (
 	ErrMobilidadeConflict = errors.New("conflict")
 	// ErrMobilidadeInvalidInput is returned for business-rule validation failures.
 	ErrMobilidadeInvalidInput = errors.New("invalid input")
+	// ErrCatalogBrandNotFound is returned when a catalog brand does not exist or is soft-deleted.
+	ErrCatalogBrandNotFound = errors.New("vehicle brand not found")
+	// ErrCatalogModelNotFound is returned when a catalog model does not exist or is soft-deleted.
+	ErrCatalogModelNotFound = errors.New("vehicle model not found")
 )
 
 // VehicleServiceInstance is the process-wide vehicle service used by handlers.
@@ -104,7 +108,7 @@ func (s *VehicleService) ListVehicles(ctx context.Context, cpf string, page, per
 	itemsByID := map[string]walletEntry{}
 	for _, v := range owned {
 		itemsByID[v.ID.Hex()] = walletEntry{
-			item:      toListItem(v, models.VehicleRoleOwner),
+			item:      toListItem(v, models.VehicleRoleOwner, ""),
 			createdAt: v.CreatedAt,
 			id:        v.ID.Hex(),
 		}
@@ -123,7 +127,7 @@ func (s *VehicleService) ListVehicles(ctx context.Context, cpf string, page, per
 			return nil, fmt.Errorf("load shared vehicle: %w", err)
 		}
 		itemsByID[v.ID.Hex()] = walletEntry{
-			item:      toListItem(v, models.VehicleRoleConductor),
+			item:      toListItem(v, models.VehicleRoleConductor, link.ID.Hex()),
 			createdAt: v.CreatedAt,
 			id:        v.ID.Hex(),
 		}
@@ -177,13 +181,13 @@ func (s *VehicleService) GetVehicle(ctx context.Context, cpf, vehicleID string) 
 		return nil, err
 	}
 
-	role, err := s.resolveRole(ctx, cpf, v)
+	role, conductorID, err := s.resolveRole(ctx, cpf, v)
 	if err != nil {
 		return nil, err
 	}
 
 	s.enrichOwnerFields(ctx, v)
-	return &models.VehicleDetail{Vehicle: *v, Role: role}, nil
+	return &models.VehicleDetail{Vehicle: *v, Role: role, ConductorID: conductorID}, nil
 }
 
 // CreateVehicle registers a new vehicle owned by cpf.
@@ -494,9 +498,9 @@ func (s *VehicleService) findVehicleForOwnerDelete(ctx context.Context, vehicleI
 	return &v, nil
 }
 
-func (s *VehicleService) resolveRole(ctx context.Context, cpf string, v *models.Vehicle) (models.VehicleRole, error) {
+func (s *VehicleService) resolveRole(ctx context.Context, cpf string, v *models.Vehicle) (models.VehicleRole, string, error) {
 	if v.OwnerCPF == cpf {
-		return models.VehicleRoleOwner, nil
+		return models.VehicleRoleOwner, "", nil
 	}
 	var link models.VehicleConductor
 	err := s.conductors().FindOne(ctx, bson.M{
@@ -505,12 +509,12 @@ func (s *VehicleService) resolveRole(ctx context.Context, cpf string, v *models.
 		"status":        models.ConductorStatusAccepted,
 	}).Decode(&link)
 	if errors.Is(err, mongo.ErrNoDocuments) {
-		return "", ErrVehicleNotFound
+		return "", "", ErrVehicleNotFound
 	}
 	if err != nil {
-		return "", fmt.Errorf("resolve role: %w", err)
+		return "", "", fmt.Errorf("resolve role: %w", err)
 	}
-	return models.VehicleRoleConductor, nil
+	return models.VehicleRoleConductor, link.ID.Hex(), nil
 }
 
 func (s *VehicleService) resolveCreateCatalogFields(ctx context.Context, req *models.VehicleCreateRequest) (
@@ -806,7 +810,7 @@ func (s *VehicleService) nextRegistrationNumber(ctx context.Context) (string, er
 	return fmt.Sprintf("RJ-E-%06d", result.Seq), nil
 }
 
-func toListItem(v models.Vehicle, role models.VehicleRole) models.VehicleListItem {
+func toListItem(v models.Vehicle, role models.VehicleRole, conductorID string) models.VehicleListItem {
 	return models.VehicleListItem{
 		ID:                 v.ID.Hex(),
 		DisplayName:        v.DisplayName,
@@ -819,5 +823,6 @@ func toListItem(v models.Vehicle, role models.VehicleRole) models.VehicleListIte
 		Color:              v.Color,
 		VehiclePhotoURL:    v.VehiclePhotoURL,
 		Role:               role,
+		ConductorID:        conductorID,
 	}
 }

--- a/internal/services/vehicle_service_test.go
+++ b/internal/services/vehicle_service_test.go
@@ -544,11 +544,15 @@ func TestVehicleService_ListVehicles_OwnerAndAcceptedConductor(t *testing.T) {
 	require.Equal(t, 2, list.Pagination.Total)
 
 	roles := map[string]models.VehicleRole{}
+	conductorIDs := map[string]string{}
 	for _, item := range list.Data {
 		roles[item.ID] = item.Role
+		conductorIDs[item.ID] = item.ConductorID
 	}
 	assert.Equal(t, models.VehicleRoleOwner, roles[owned.ID.Hex()])
+	assert.Empty(t, conductorIDs[owned.ID.Hex()])
 	assert.Equal(t, models.VehicleRoleConductor, roles[shared.ID.Hex()])
+	assert.Equal(t, invites.Data[0].ID, conductorIDs[shared.ID.Hex()])
 }
 
 func TestVehicleService_ListVehicles_ExcludesPendingOnly(t *testing.T) {
@@ -578,6 +582,7 @@ func TestVehicleService_GetVehicle_OwnerAndConductor(t *testing.T) {
 	detail, err := vehicleSvc.GetVehicle(context.Background(), mobilidadeOwnerCPF, created.ID.Hex())
 	require.NoError(t, err)
 	assert.Equal(t, models.VehicleRoleOwner, detail.Role)
+	assert.Empty(t, detail.ConductorID)
 	assert.Equal(t, "SN-ABC-123456", detail.SerialNumber)
 
 	_, err = conductorSvc.InviteConductor(context.Background(), mobilidadeOwnerCPF, created.ID.Hex(), &models.InviteConductorRequest{CPF: mobilidadeConductorCPF, Email: "joao@example.com", Name: "João Condutor"})
@@ -592,6 +597,7 @@ func TestVehicleService_GetVehicle_OwnerAndConductor(t *testing.T) {
 	asConductor, err := vehicleSvc.GetVehicle(context.Background(), mobilidadeConductorCPF, created.ID.Hex())
 	require.NoError(t, err)
 	assert.Equal(t, models.VehicleRoleConductor, asConductor.Role)
+	assert.Equal(t, invites.Data[0].ID, asConductor.ConductorID)
 }
 
 func TestVehicleService_GetVehicle_ForbiddenForStranger(t *testing.T) {
@@ -1007,6 +1013,35 @@ func TestVehicleConductorService_InvitePersistsFormSnapshot(t *testing.T) {
 	require.Len(t, list.Data, 1)
 	assert.Equal(t, "Nome Digitado", list.Data[0].ConductorName)
 	assert.Equal(t, "convite@example.com", list.Data[0].NotifyEmail)
+	assert.Equal(t, "21999990000", list.Data[0].Phone)
+}
+
+func TestListConductors_AcceptedReplacesInviteSnapshotWithCitizenProfile(t *testing.T) {
+	vehicleSvc, conductorSvc, _, cleanup := setupMobilidadeVehicleServiceTest(t)
+	defer cleanup()
+	seedMobilidadeCatalog(t)
+
+	created, err := vehicleSvc.CreateVehicle(context.Background(), mobilidadeOwnerCPF, catalogCreateRequest())
+	require.NoError(t, err)
+
+	link, err := conductorSvc.InviteConductor(context.Background(), mobilidadeOwnerCPF, created.ID.Hex(), &models.InviteConductorRequest{
+		CPF: mobilidadeConductorCPF, Email: "convite@example.com", Name: "Nome Digitado", Phone: "21999990000",
+	})
+	require.NoError(t, err)
+	_, err = conductorSvc.RespondInvitation(context.Background(), mobilidadeConductorCPF, link.ID.Hex(), &models.RespondInvitationRequest{
+		Status: models.InvitationResponseAccepted,
+	})
+	require.NoError(t, err)
+
+	list, err := conductorSvc.ListConductors(context.Background(), mobilidadeOwnerCPF, created.ID.Hex())
+	require.NoError(t, err)
+	require.Len(t, list.Data, 1)
+	assert.Equal(t, models.ConductorStatusAccepted, list.Data[0].Status)
+	assert.Equal(t, "João Condutor", list.Data[0].ConductorName)
+	assert.Equal(t, "joao@example.com", list.Data[0].NotifyEmail)
+	assert.Empty(t, list.Data[0].Phone)
+	assert.NotEqual(t, "Nome Digitado", list.Data[0].ConductorName)
+	assert.NotEqual(t, "convite@example.com", list.Data[0].NotifyEmail)
 }
 
 func TestListConductors_AcceptedEnrichesLiveRMI(t *testing.T) {
@@ -1035,4 +1070,37 @@ func TestListConductors_AcceptedEnrichesLiveRMI(t *testing.T) {
 	assert.Equal(t, "joao.novo@example.com", list.Data[0].NotifyEmail)
 	assert.NotEmpty(t, list.Data[0].Phone)
 	assert.Contains(t, list.Data[0].Phone, "988887777")
+}
+
+func TestListConductors_AcceptedClearsSnapshotWhenRMIEmpty(t *testing.T) {
+	vehicleSvc, conductorSvc, _, cleanup := setupMobilidadeVehicleServiceTest(t)
+	defer cleanup()
+	seedMobilidadeCatalog(t)
+
+	created, err := vehicleSvc.CreateVehicle(context.Background(), mobilidadeOwnerCPF, catalogCreateRequest())
+	require.NoError(t, err)
+
+	link, err := conductorSvc.InviteConductor(context.Background(), mobilidadeOwnerCPF, created.ID.Hex(), &models.InviteConductorRequest{
+		CPF: mobilidadeConductorCPF, Email: "convite@example.com", Name: "Nome Digitado", Phone: "21999990000",
+	})
+	require.NoError(t, err)
+	_, err = conductorSvc.RespondInvitation(context.Background(), mobilidadeConductorCPF, link.ID.Hex(), &models.RespondInvitationRequest{
+		Status: models.InvitationResponseAccepted,
+	})
+	require.NoError(t, err)
+
+	// Remove citizen so live profile is empty — response must not fall back to invite snapshot.
+	_, err = config.MongoDB.Collection(config.AppConfig.CitizenCollection).DeleteMany(context.Background(), bson.M{"cpf": mobilidadeConductorCPF})
+	require.NoError(t, err)
+	_, err = config.MongoDB.Collection(config.AppConfig.SelfDeclaredCollection).DeleteMany(context.Background(), bson.M{"cpf": mobilidadeConductorCPF})
+	require.NoError(t, err)
+	invalidateMobilidadeContactCache(t, mobilidadeConductorCPF)
+
+	list, err := conductorSvc.ListConductors(context.Background(), mobilidadeOwnerCPF, created.ID.Hex())
+	require.NoError(t, err)
+	require.Len(t, list.Data, 1)
+	assert.Equal(t, models.ConductorStatusAccepted, list.Data[0].Status)
+	assert.Empty(t, list.Data[0].ConductorName)
+	assert.Empty(t, list.Data[0].NotifyEmail)
+	assert.Empty(t, list.Data[0].Phone)
 }

--- a/internal/utils/mobilidade_slug.go
+++ b/internal/utils/mobilidade_slug.go
@@ -4,22 +4,37 @@ import (
 	"regexp"
 	"strings"
 	"unicode"
+
+	"golang.org/x/text/runes"
+	"golang.org/x/text/transform"
+	"golang.org/x/text/unicode/norm"
 )
 
 var mobilidadeNonAlnum = regexp.MustCompile(`[^a-z0-9]+`)
 
-// MobilidadeSlugify converts a catalog label to a stable lowercase slug (seed script parity).
+// MobilidadeSlugify converts a catalog label to a stable lowercase ASCII slug.
+// Accents are folded (São Paulo → sao_paulo); separators become underscores.
 func MobilidadeSlugify(s string) string {
+	s = foldAccents(strings.ToLower(strings.TrimSpace(s)))
 	var b strings.Builder
-	for _, r := range strings.ToLower(strings.TrimSpace(s)) {
+	for _, r := range s {
 		switch {
-		case unicode.IsLetter(r) || unicode.IsDigit(r):
+		case (r >= 'a' && r <= 'z') || (r >= '0' && r <= '9'):
 			b.WriteRune(r)
 		case unicode.IsSpace(r) || r == '-' || r == '_':
 			b.WriteByte('_')
 		}
 	}
 	return strings.Trim(mobilidadeNonAlnum.ReplaceAllString(b.String(), "_"), "_")
+}
+
+func foldAccents(s string) string {
+	t := transform.Chain(norm.NFD, runes.Remove(runes.In(unicode.Mn)), norm.NFC)
+	out, _, err := transform.String(t, s)
+	if err != nil {
+		return s
+	}
+	return out
 }
 
 // MobilidadeBrandIDFromName returns brand_<slug> for a catalog brand name.

--- a/internal/utils/mobilidade_slug.go
+++ b/internal/utils/mobilidade_slug.go
@@ -1,0 +1,33 @@
+package utils
+
+import (
+	"regexp"
+	"strings"
+	"unicode"
+)
+
+var mobilidadeNonAlnum = regexp.MustCompile(`[^a-z0-9]+`)
+
+// MobilidadeSlugify converts a catalog label to a stable lowercase slug (seed script parity).
+func MobilidadeSlugify(s string) string {
+	var b strings.Builder
+	for _, r := range strings.ToLower(strings.TrimSpace(s)) {
+		switch {
+		case unicode.IsLetter(r) || unicode.IsDigit(r):
+			b.WriteRune(r)
+		case unicode.IsSpace(r) || r == '-' || r == '_':
+			b.WriteByte('_')
+		}
+	}
+	return strings.Trim(mobilidadeNonAlnum.ReplaceAllString(b.String(), "_"), "_")
+}
+
+// MobilidadeBrandIDFromName returns brand_<slug> for a catalog brand name.
+func MobilidadeBrandIDFromName(name string) string {
+	return "brand_" + MobilidadeSlugify(name)
+}
+
+// MobilidadeModelIDFromBrandAndName returns model_<brandSlug>_<modelSlug>.
+func MobilidadeModelIDFromBrandAndName(brandName, modelName string) string {
+	return "model_" + MobilidadeSlugify(brandName) + "_" + MobilidadeSlugify(modelName)
+}

--- a/internal/utils/mobilidade_slug_test.go
+++ b/internal/utils/mobilidade_slug_test.go
@@ -1,0 +1,32 @@
+package utils
+
+import "testing"
+
+func TestMobilidadeSlugify(t *testing.T) {
+	cases := []struct {
+		in, want string
+	}{
+		{"Caloi", "caloi"},
+		{"E-Bike X", "e_bike_x"},
+		{"  Mi Electric  ", "mi_electric"},
+		{"São Paulo", "sao_paulo"},
+		{"A/B", "ab"}, // '/' dropped (not mapped to '_')
+		{"", ""},
+		{"Ação", "acao"},
+		{"Ñandú", "nandu"},
+	}
+	for _, tc := range cases {
+		if got := MobilidadeSlugify(tc.in); got != tc.want {
+			t.Errorf("MobilidadeSlugify(%q) = %q, want %q", tc.in, got, tc.want)
+		}
+	}
+}
+
+func TestMobilidadeBrandAndModelIDs(t *testing.T) {
+	if got := MobilidadeBrandIDFromName("Monark"); got != "brand_monark" {
+		t.Errorf("MobilidadeBrandIDFromName = %q", got)
+	}
+	if got := MobilidadeModelIDFromBrandAndName("Monark", "E-Bike X"); got != "model_monark_e_bike_x" {
+		t.Errorf("MobilidadeModelIDFromBrandAndName = %q", got)
+	}
+}

--- a/scripts/seed_mobilidade_catalog/main.go
+++ b/scripts/seed_mobilidade_catalog/main.go
@@ -19,13 +19,12 @@ import (
 	"fmt"
 	"log"
 	"os"
-	"regexp"
 	"strings"
 	"time"
-	"unicode"
 
 	"github.com/prefeitura-rio/app-rmi/internal/config"
 	"github.com/prefeitura-rio/app-rmi/internal/models"
+	"github.com/prefeitura-rio/app-rmi/internal/utils"
 	"go.mongodb.org/mongo-driver/bson"
 	"go.mongodb.org/mongo-driver/mongo/options"
 )
@@ -57,7 +56,7 @@ func main() {
 	upsertOpts := options.Update().SetUpsert(true)
 
 	for _, row := range rows {
-		brandID := "brand_" + slugify(row.marca)
+		brandID := "brand_" + utils.MobilidadeSlugify(row.marca)
 		if _, err := brands.UpdateOne(ctx, bson.M{"_id": brandID}, bson.M{"$set": bson.M{
 			"name":     row.marca,
 			"is_other": false,
@@ -65,7 +64,7 @@ func main() {
 			log.Fatalf("upsert brand %s: %v", brandID, err)
 		}
 
-		modelID := "model_" + slugify(row.marca) + "_" + slugify(row.modelo)
+		modelID := "model_" + utils.MobilidadeSlugify(row.marca) + "_" + utils.MobilidadeSlugify(row.modelo)
 		if _, err := modelsCol.UpdateOne(ctx, bson.M{"_id": modelID}, bson.M{"$set": bson.M{
 			"brand_id":     brandID,
 			"name":         row.modelo,
@@ -138,19 +137,4 @@ func readCatalogCSV(path string) ([]catalogRow, error) {
 		})
 	}
 	return rows, nil
-}
-
-var nonAlnum = regexp.MustCompile(`[^a-z0-9]+`)
-
-func slugify(s string) string {
-	var b strings.Builder
-	for _, r := range strings.ToLower(strings.TrimSpace(s)) {
-		switch {
-		case unicode.IsLetter(r) || unicode.IsDigit(r):
-			b.WriteRune(r)
-		case unicode.IsSpace(r) || r == '-' || r == '_':
-			b.WriteByte('_')
-		}
-	}
-	return strings.Trim(nonAlnum.ReplaceAllString(b.String(), "_"), "_")
 }


### PR DESCRIPTION
## Contexto

A carteira de mobilidade (veículos/condutores/catálogo) já estava em uso no app, mas faltavam três ajustes de contrato e operação:

1. o front não recebia o `conductor_id` nos GETs de veículos quando o usuário é condutor aceito (necessário para self-leave / ações no vínculo);
2. a listagem de condutores misturava/podia manter snapshot do convite após o aceite, em vez de refletir o perfil atual no RMI;
3. marcas e modelos só existiam via seed CSV — sem CRUD admin tipado no padrão RMI (`/admin/...`, Bearer, Orval).

## Causa

- `ListVehicles` / `GetVehicle` calculavam `role`, mas não devolviam o id do `VehicleConductor` aceito.
- O overlay RMI em `accepted` só preenchia campos quando o perfil vinha não vazio, permitindo fallback implícito para o snapshot do convite.
- O catálogo era somente leitura (`GET /mobilidade/vehicle-*`); não havia endpoints admin para criar/editar/remover marcas e modelos.

## Solução

- Incluir `conductor_id` (omitido para `owner`) em `GET /citizen/{cpf}/vehicles` e `GET /citizen/{cpf}/vehicles/{vehicle_id}` quando `role === "conductor"`.
- Em `GET .../conductors`: `pending` → snapshot do convite; `accepted` → `conductor_name` / `notify_email` / `phone` sempre do RMI ao vivo (sem fallback para o snapshot).
- CRUD admin tipado:
  - `/admin/mobilidade/vehicle-brands` (GET/POST/PATCH/DELETE)
  - `/admin/mobilidade/vehicle-models` (GET/POST/PATCH/DELETE)
- Soft-delete via `deleted_at`; GETs públicos do cidadão continuam iguais no contrato e passam a listar só ativos.
- Sentinels `brand_outro` / `model_outro` protegidos; unicidade e referências a veículos → `409`.

## Testes

- [x] Service/HTTP para `conductor_id` (owner vs conductor)
- [x] Enrichment: pending snapshot, accepted com citizen/self-declared, accepted com RMI vazio (sem fallback)
- [x] Admin catálogo: happy path, duplicata `409`, sentinel `400`, `404`, validação `400`
- [x] Delete marca com modelos `409`; soft-delete some do GET público
- [x] PATCH/DELETE bloqueados quando veículo referencia marca/modelo
- [x] `mapMobilidadeError` cobre `ErrCatalogBrandNotFound` / `ErrCatalogModelNotFound`
- [x] Swagger regenerado com request/response tipados para Orval